### PR TITLE
Add install target for cmetrics library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,7 @@ set(CMT_VERSION_STR "${CMT_VERSION_MAJOR}.${CMT_VERSION_MINOR}.${CMT_VERSION_PAT
 # Include helpers
 include(cmake/macros.cmake)
 include(CheckCSourceCompiles)
+include(GNUInstallDirs)
 
 # Configuration options
 option(CMT_DEV     "Enable development mode"  No)
@@ -88,4 +89,14 @@ add_subdirectory(src)
 if(CMT_TESTS)
   enable_testing()
   add_subdirectory(tests)
+endif()
+
+# Installation Directories
+# ========================
+if(${CMAKE_SYSTEM_NAME} MATCHES "Windows")
+  set(CMT_INSTALL_LIBDIR "lib")
+  set(CMT_INSTALL_INCLUDEDIR "include")
+else()
+  set(CMT_INSTALL_LIBDIR "${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}")
+  set(CMT_INSTALL_INCLUDEDIR "${CMAKE_INSTALL_PREFIX}/include")
 endif()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -31,3 +31,13 @@ set(src
 # Static Library
 add_library(cmetrics-static STATIC ${src})
 target_link_libraries(cmetrics-static xxhash mpack-static)
+
+# Install Library
+if(MSVC)
+  # Rename the output for Windows environment to avoid naming issues
+  set_target_properties(cmetrics-static PROPERTIES OUTPUT_NAME libcmetrics)
+else()
+  set_target_properties(cmetrics-static PROPERTIES OUTPUT_NAME cmetrics)
+endif(MSVC)
+
+install(TARGETS cmetrics-static RUNTIME DESTINATION ${CMT_INSTALL_LIBDIR} COMPONENT binary)


### PR DESCRIPTION
This is needed for miniportile's cmake building process.

Signed-off-by: Hiroshi Hatake <hatake@calyptia.com>