### PR TITLE
Ensure to enable cmetrics tests on msvc

### DIFF
--- a/scripts/win_build.bat
+++ b/scripts/win_build.bat
@@ -1,6 +1,6 @@
 setlocal
 call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\Common7\Tools\VsDevCmd.bat"
 path "C:\Program Files (x86)\MSBuild\16.0\Bin;C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\MSBuild\Current\Bin";%path%
-cmake -G "Visual Studio 16 2019" .
+cmake -G "Visual Studio 16 2019" -DCMT_TESTS=On .
 msbuild cmetrics.sln /property:Configuration=Debug -maxcpucount:2
 endlocal


### PR DESCRIPTION
`-DCMT_TESTS=On` also should be added in scripts/win_build.bat.

Signed-off-by: Hiroshi Hatake <hatake@calyptia.com>