### PR TITLE
Add headers as install targets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -82,16 +82,6 @@ if(NOT TARGET mpack-static)
   add_subdirectory(lib/mpack EXCLUDE_FROM_ALL)
 endif()
 
-# Source code
-add_subdirectory(include)
-add_subdirectory(src)
-
-# Tests
-if(CMT_TESTS)
-  enable_testing()
-  add_subdirectory(tests)
-endif()
-
 # Installation Directories
 # ========================
 if(${CMAKE_SYSTEM_NAME} MATCHES "Windows")
@@ -100,4 +90,14 @@ if(${CMAKE_SYSTEM_NAME} MATCHES "Windows")
 else()
   set(CMT_INSTALL_LIBDIR "${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}")
   set(CMT_INSTALL_INCLUDEDIR "${CMAKE_INSTALL_PREFIX}/include")
+endif()
+
+# Source code
+add_subdirectory(include)
+add_subdirectory(src)
+
+# Tests
+if(CMT_TESTS)
+  enable_testing()
+  add_subdirectory(tests)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -83,6 +83,7 @@ if(NOT TARGET mpack-static)
 endif()
 
 # Source code
+add_subdirectory(include)
 add_subdirectory(src)
 
 # Tests

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -95,6 +95,7 @@ endif()
 # Source code
 add_subdirectory(include)
 add_subdirectory(src)
+add_subdirectory(lib/monkey/include)
 
 # Tests
 if(CMT_TESTS)

--- a/include/CMakeLists.txt
+++ b/include/CMakeLists.txt
@@ -1,0 +1,5 @@
+file(GLOB headers "cmetrics/*.h")
+install(FILES ${headers}
+    DESTINATION ${CMT_INSTALL_INCLUDEDIR}/cmetrics
+    COMPONENT headers
+    PERMISSIONS OWNER_READ OWNER_WRITE GROUP_READ WORLD_READ)

--- a/lib/monkey/include/CMakeLists.txt
+++ b/lib/monkey/include/CMakeLists.txt
@@ -1,0 +1,11 @@
+file(GLOB headers "monkey/mk_core/*.h")
+install(FILES ${headers}
+    DESTINATION ${CMT_INSTALL_INCLUDEDIR}/monkey/mk_core
+    COMPONENT headers
+    PERMISSIONS OWNER_READ OWNER_WRITE GROUP_READ WORLD_READ)
+
+file(GLOB headers "monkey/mk_core/external/*.h")
+install(FILES ${headers}
+    DESTINATION ${CMT_INSTALL_INCLUDEDIR}/monkey/mk_core/external
+    COMPONENT headers
+    PERMISSIONS OWNER_READ OWNER_WRITE GROUP_READ WORLD_READ)


### PR DESCRIPTION
Headers are also needed as install targets.
This is also needed for miniportile's cmake building process.