### PR TITLE
build: Specify ARCHIVE and LIBRARY destinations to be able to built w/ CMAKE 3.10

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -40,4 +40,8 @@ else()
   set_target_properties(cmetrics-static PROPERTIES OUTPUT_NAME cmetrics)
 endif(MSVC)
 
-install(TARGETS cmetrics-static RUNTIME DESTINATION ${CMT_INSTALL_LIBDIR} COMPONENT binary)
+install(TARGETS cmetrics-static
+  RUNTIME DESTINATION ${CMT_INSTALL_BINDIR}
+  LIBRARY DESTINATION ${CMT_INSTALL_LIBDIR}
+  ARCHIVE DESTINATION ${CMT_INSTALL_LIBDIR}
+  COMPONENT binary)


### PR DESCRIPTION
CMake v3.10 complains lack of ARCHIVE and LIBRARY destinations....
I'd overlooked this issue.

Signed-off-by: Hiroshi Hatake <hatake@calyptia.com>