### PR TITLE
Specify position indepentent code flag explicitly

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,6 @@
 cmake_minimum_required(VERSION 2.8)
 project(cmetrics C)
+set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
 # CMetrics Version
 set(CMT_VERSION_MAJOR  0)


### PR DESCRIPTION
CMake v3.10 does not specify this flag by default.
Ubuntu 18.04 LTS still uses cmake v3.10.

Signed-off-by: Hiroshi Hatake <hatake@calyptia.com>