### PR TITLE
cmt_encode_msgpack: Pass cmt type in msgpack header encoder

### DIFF
--- a/src/cmt_encode_msgpack.c
+++ b/src/cmt_encode_msgpack.c
@@ -26,7 +26,7 @@
 
 #include <mpack/mpack.h>
 
-static void pack_header(mpack_writer_t *writer, struct cmt_map *map)
+static void pack_header(mpack_writer_t *writer, struct cmt_map *map, int cmt_type)
 {
     struct mk_list *head;
     struct cmt_map_label *label;
@@ -36,7 +36,7 @@ static void pack_header(mpack_writer_t *writer, struct cmt_map *map)
 
     /* 'type' */
     mpack_write_cstr(writer, "type");
-    mpack_write_uint(writer, 0);
+    mpack_write_uint(writer, cmt_type);
 
     /* 'opts' */
     mpack_write_cstr(writer, "opts");
@@ -113,13 +113,13 @@ static int pack_metric(mpack_writer_t *writer, int type, struct cmt_metric *metr
     mpack_finish_map(writer);
 }
 
-static int pack_basic_type(mpack_writer_t *writer, struct cmt_map *map)
+static int pack_basic_type(mpack_writer_t *writer, struct cmt_map *map, int cmt_type)
 {
     int values_size = 0;
     struct mk_list *head;
     struct cmt_metric *metric;
 
-    pack_header(writer, map);
+    pack_header(writer, map, cmt_type);
 
     if (map->metric_static_set) {
         values_size++;
@@ -183,13 +183,13 @@ int cmt_encode_msgpack_to_msgpack(struct cmt *cmt, char **out_buf, size_t *out_s
     /* Counters */
     mk_list_foreach(head, &cmt->counters) {
         counter = mk_list_entry(head, struct cmt_counter, _head);
-        pack_basic_type(&writer, counter->map);
+        pack_basic_type(&writer, counter->map, CMT_COUNTER);
     }
 
     /* Gauges */
     mk_list_foreach(head, &cmt->gauges) {
         gauge = mk_list_entry(head, struct cmt_gauge, _head);
-        pack_basic_type(&writer, gauge->map);
+        pack_basic_type(&writer, gauge->map, CMT_GAUGE);
     }
 
     if (mpack_writer_destroy(&writer) != mpack_ok) {


### PR DESCRIPTION
With current master implementation, pack_header can't distinguish CMT
types.
This is because counter, gauge, and histogram are having cmt_map members
and always handled same function signatures on msgpack encoder:
mpack_writer_t*, struct cmt_map*

This indicates that previous pack_basic_type does not distinguish
between three counter, gauge, and histogram types on caller.

This unimplemented things should be fixed.

Signed-off-by: Hiroshi Hatake <hatake@calyptia.com>

---

**Additional context**

I'd confirmed this behavior on cmetrics-ruby side and I was surprised this unimplemented things:

```ruby
irb> require 'cmetrics'
=> true
irb> gauge = CMetrics::Gauge.new
=> #<CMetrics::Gauge:0x00007fcb52296f10>
irb> gauge.create("kubernetes", "network", "load", "Network load", ["hostname", "app"])
=> nil
irb>  gauge.inc(["localhost", "cmetrics"])
=> true
irb> msgp = gauge.to_msgpack
=> "\x84\xA4type\x00\xA4opts\x85\xA2ns\xAAkubernetes\xA2ss\xA7network\xA4name\xA4load\xA4desc\xACNetwork load\xA6fqname...
irb> require 'msgpack'
=> true
irb> MessagePack.unpack(msgp)
=> 
{"type"=>0, # <= This should be 1 here.
 "opts"=>{"ns"=>"kubernetes", "ss"=>"network", "name"=>"load", "desc"=>"Network load", "fqname"=>"kubernetes_network_load"},
 "labels"=>["hostname", "app"],
 "values"=>[{"ts"=>1624200292746712000, "value"=>1.0, "labels"=>["localhost", "cmetrics"]}]}
```

W/ this fix:

```ruby
irb> require 'cmetrics'
=> true
irb> gauge = CMetrics::Gauge.new
=> #<CMetrics::Gauge:0x00007f8a9c097a30>
irb> gauge.create("kubernetes", "network", "load", "Network load", ["hostname", "app"])
=> nil
irb>  gauge.inc(["localhost", "cmetrics"])
=> true
irb> msgp = gauge.to_msgpack
=> "\x84\xA4type\x01\xA4opts\x85\xA2ns\xAAkubernetes\xA2ss\xA7network\xA4name\xA4load\xA4desc\xACNetwork load\xA6fqname...
irb> require 'msgpack'
irb> MessagePack.unpack(msgp)
=> 
{"type"=>1,
 "opts"=>{"ns"=>"kubernetes", "ss"=>"network", "name"=>"load", "desc"=>"Network load", "fqname"=>"kubernetes_network_load"},
 "labels"=>["hostname", "app"],
 "values"=>[{"ts"=>1624200801835455000, "value"=>1.0, "labels"=>["localhost", "cmetrics"]}]}
```