### PR TITLE
workflows: add package build/store for deb/rpm.

### DIFF
--- a/.github/workflows/packages.yaml
+++ b/.github/workflows/packages.yaml
@@ -1,0 +1,28 @@
+on:
+  push:
+    branches:
+      - master
+
+name: Build packages for master
+jobs:
+  build-distro-packages:
+    name: build packages
+    strategy:
+      fail-fast: true
+      matrix:
+        distro: [ rpm, deb ]
+
+    runs-on: [ ubuntu-latest ]
+    steps:
+      - uses: actions/checkout@v2
+      - name: Build the ${{matrix.format}} packages
+        run:  |
+          cmake .
+          echo ${{ matrix.format }} | awk '{print toupper($0)}' | xargs -I{} cpack -G {}
+
+      - name: Store the master package artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: ${{ matrix.format }}
+          path: |
+            ./*.${{matrix.format}}


### PR DESCRIPTION
* build deb/rpm packages for library/headers and store them on the action artifacts.