### PR TITLE
compat: build: Extract Windows compatibility layer function to cmt_compat.h

### DIFF
--- a/include/cmetrics/cmt_compat.h
+++ b/include/cmetrics/cmt_compat.h
@@ -17,13 +17,19 @@
  *  limitations under the License.
  */
 
-#ifndef CMT_TIME_H
-#define CMT_TIME_H
+#ifndef CMT_COMPAT_H
+#define CMT_COMPAT_H
 
-#include <inttypes.h>
 #include <time.h>
 
-uint64_t cmt_time_now();
-void cmt_time_from_ns(struct timespec *tm, uint64_t ns);
+#if CMT_HAVE_GMTIME_S
+static inline struct tm *gmtime_r(const time_t *timep, struct tm *result)
+{
+    if (gmtime_s(result, timep)) {
+        return NULL;
+    }
+    return result;
+}
+#endif
 
 #endif

--- a/src/cmt_encode_text.c
+++ b/src/cmt_encode_text.c
@@ -24,6 +24,7 @@
 #include <cmetrics/cmt_counter.h>
 #include <cmetrics/cmt_gauge.h>
 #include <cmetrics/cmt_time.h>
+#include <cmetrics/cmt_compat.h>
 
 static void sds_cat_safe(cmt_sds_t *buf, const char *str, int len)
 {


### PR DESCRIPTION
This is because downstream Ruby binding does not know how to handle `CMT_HAVE_GMTIME_S` constant which is defined by cmake.
This compatibility layer should be separated from main headers.
 
Signed-off-by: Hiroshi Hatake <hatake@calyptia.com>