### PR TITLE
Include windows.h on  win32 environment explicitly and unify mk_list.h definition from fluent-bit uses one

### DIFF
--- a/include/cmetrics/cmt_compat.h
+++ b/include/cmetrics/cmt_compat.h
@@ -21,6 +21,9 @@
 #define CMT_COMPAT_H
 
 #include <time.h>
+#ifdef _WIN32
+#include <windows.h>
+#endif
 
 #if CMT_HAVE_GMTIME_S
 static inline struct tm *gmtime_r(const time_t *timep, struct tm *result)

--- a/lib/monkey/include/monkey/mk_core/mk_list.h
+++ b/lib/monkey/include/monkey/mk_core/mk_list.h
@@ -25,8 +25,6 @@
 
 #ifdef _WIN32
 /* Windows */
-#include <windows.h>
-
 #define container_of(address, type, field) ((type *)(                   \
                                                      (PCHAR)(address) - \
                                                      (ULONG_PTR)(&((type *)0)->field)))

--- a/src/cmetrics.c
+++ b/src/cmetrics.c
@@ -21,6 +21,7 @@
 #include <cmetrics/cmt_log.h>
 #include <cmetrics/cmt_gauge.h>
 #include <cmetrics/cmt_counter.h>
+#include <cmetrics/cmt_compat.h>
 
 #include <stdlib.h>
 

--- a/src/cmt_decode_msgpack.c
+++ b/src/cmt_decode_msgpack.c
@@ -24,6 +24,7 @@
 #include <cmetrics/cmt_counter.h>
 #include <cmetrics/cmt_gauge.h>
 #include <cmetrics/cmt_decode_msgpack.h>
+#include <cmetrics/cmt_compat.h>
 
 #include <mpack/mpack.h>
 

--- a/src/cmt_encode_msgpack.c
+++ b/src/cmt_encode_msgpack.c
@@ -23,6 +23,7 @@
 #include <cmetrics/cmt_sds.h>
 #include <cmetrics/cmt_counter.h>
 #include <cmetrics/cmt_gauge.h>
+#include <cmetrics/cmt_compat.h>
 
 #include <mpack/mpack.h>
 

--- a/src/cmt_encode_prometheus.c
+++ b/src/cmt_encode_prometheus.c
@@ -23,6 +23,7 @@
 #include <cmetrics/cmt_sds.h>
 #include <cmetrics/cmt_counter.h>
 #include <cmetrics/cmt_gauge.h>
+#include <cmetrics/cmt_compat.h>
 
 /*
  * Prometheus Exposition Format

--- a/src/cmt_log.c
+++ b/src/cmt_log.c
@@ -19,6 +19,7 @@
 
 #include <cmetrics/cmetrics.h>
 #include <cmetrics/cmt_log.h>
+#include <cmetrics/cmt_compat.h>
 
 #include <stdio.h>
 #include <stdarg.h>

--- a/src/cmt_map.c
+++ b/src/cmt_map.c
@@ -23,6 +23,7 @@
 #include <cmetrics/cmt_log.h>
 #include <cmetrics/cmt_hash.h>
 #include <cmetrics/cmt_metric.h>
+#include <cmetrics/cmt_compat.h>
 
 struct cmt_map *cmt_map_create(int type, struct cmt_opts *opts, int count, char **labels)
 {


### PR DESCRIPTION
On cmetrics itself, it does not cause undeclared identifier problems due to mk_list.h includes `<windows.h>`.
But, bundled cmetrics on fluent-bit causes these issues because fluent-bit bundled mk_list.h does not include windows.h.
This header definition glitch causes building failure at fluent-bit.