### PR TITLE
compat: encode_text: Use cmt_platform prefix-ed gmtime_r|s wrap function

### DIFF
--- a/include/cmetrics/cmt_compat.h
+++ b/include/cmetrics/cmt_compat.h
@@ -25,14 +25,18 @@
 #include <windows.h>
 #endif
 
-#if CMT_HAVE_GMTIME_S
-static inline struct tm *gmtime_r(const time_t *timep, struct tm *result)
+static inline struct tm *cmt_platform_gmtime_r(const time_t *timep, struct tm *result)
 {
+#ifdef CMT_HAVE_GMTIME_S
     if (gmtime_s(result, timep)) {
         return NULL;
     }
+
     return result;
-}
+#else
+    /* FIXME: Need to handle gmtime_r(3) lacking platform? */
+    return gmtime_r(timep, result) ;
 #endif
+}
 
 #endif

--- a/src/cmt_encode_text.c
+++ b/src/cmt_encode_text.c
@@ -65,7 +65,7 @@ static void format_metric(struct cmt *cmt, cmt_sds_t *buf, struct cmt_map *map,
 
     cmt_time_from_ns(&tms, ts);
 
-    gmtime_r(&tms.tv_sec, &tm);
+    cmt_platform_gmtime_r(&tms.tv_sec, &tm);
     len = strftime(tmp, sizeof(tmp) - 1, "%Y-%m-%dT%H:%M:%S.", &tm);
     cmt_sds_cat_safe(buf, tmp, len);
 


### PR DESCRIPTION
This is because fluent-bit is already provided similiar function on its compat layer.
Ruby is also provided its gmtime_s|r wrapper in ruby.h.

We should use `cmt_platform_` prefix to wrap `gmtime_s` and `gmtime_r` functions.

And I fixed `#ifdef CMT_HAVE_GMTIME_S` from `#if CMT_HAVE_GMTIME_S`, too.

Signed-off-by: Hiroshi Hatake <hatake@calyptia.com>