### PR TITLE
msgpack: fixed wrong attribution of decoded gauges as counters

### DIFF
--- a/include/cmetrics/cmt_encode_msgpack.h
+++ b/include/cmetrics/cmt_encode_msgpack.h
@@ -23,7 +23,7 @@
 
 #include <cmetrics/cmetrics.h>
 
-#define MSGPACK_ENCODER_VERSION 1
+#define MSGPACK_ENCODER_VERSION 2
 
 int cmt_encode_msgpack_create(struct cmt *cmt, char **out_buf, size_t *out_size);
 void cmt_encode_msgpack_destroy(char *out_buf);

--- a/src/cmt_decode_msgpack.c
+++ b/src/cmt_decode_msgpack.c
@@ -708,7 +708,7 @@ static int append_unpacked_gauge_to_metrics_context(struct cmt *context,
 
     map->opts = &gauge->opts;
 
-    mk_list_add(&gauge->_head, &context->counters);
+    mk_list_add(&gauge->_head, &context->gauges);
 
     return CMT_DECODE_MSGPACK_SUCCESS;
 }


### PR DESCRIPTION
msgpack : bumped the encoder version to 2 because of the untyped metric addition

Signed-off-by: Leonardo Almiñana <leonardo@calyptia.com>