### PR TITLE
Bundle Prometheus remote write headers

### DIFF
--- a/include/CMakeLists.txt
+++ b/include/CMakeLists.txt
@@ -1,5 +1,11 @@
-file(GLOB headers "cmetrics/*.h")
-install(FILES ${headers}
+file(GLOB cmetricsHeaders "cmetrics/*.h")
+install(FILES ${cmetricsHeaders}
     DESTINATION ${CMT_INSTALL_INCLUDEDIR}/cmetrics
+    COMPONENT headers
+    PERMISSIONS OWNER_READ OWNER_WRITE GROUP_READ WORLD_READ)
+
+file(GLOB promHeaders "prometheus_remote_write/*.h")
+install(FILES ${promHeaders}
+    DESTINATION ${CMT_INSTALL_INCLUDEDIR}/prometheus_remote_write
     COMPONENT headers
     PERMISSIONS OWNER_READ OWNER_WRITE GROUP_READ WORLD_READ)


### PR DESCRIPTION
These headers could be needed for implementing prometheus remoting on
cmetrics Ruby binding.

Prometheus remote write headers related file is included in cmetrics/cmt_encode_prometheus_remote_write.h:
https://github.com/calyptia/cmetrics/blob/8faa8591cbcb7f3f4a458b4ce779762d994c926c/include/cmetrics/cmt_encode_prometheus_remote_write.h#L26

Signed-off-by: Hiroshi Hatake <hatake@calyptia.com>