### PR TITLE
time: fix compile error on mac

### DIFF
--- a/src/cmt_time.c
+++ b/src/cmt_time.c
@@ -41,8 +41,8 @@ uint64_t cmt_time_now()
     mach_timespec_t mts;
     host_get_clock_service(mach_host_self(), CALENDAR_CLOCK, &cclock);
     clock_get_time(cclock, &mts);
-    tm->tv_sec = mts.tv_sec;
-    tm->tv_nsec = mts.tv_nsec;
+    tm.tv_sec = mts.tv_sec;
+    tm.tv_nsec = mts.tv_nsec;
     mach_port_deallocate(mach_task_self(), cclock);
 #else /* __STDC_VERSION__ */
     clock_gettime(CLOCK_REALTIME, &tm);


### PR DESCRIPTION
Found this while compiling fluent-bit 1.8.9
```
# make
...
Apple LLVM version 10.0.1 (clang-1001.0.46.4)
Target: x86_64-apple-darwin18.7.0
Thread model: posix
...
../src/cmt_time.c:44:7: error: member reference type 'struct timespec' is not a pointer; did you mean to use '.'?
    tm->tv_sec = mts.tv_sec;
    ~~^~
      .
../src/cmt_time.c:44:16: error: expression is not assignable
    tm->tv_sec = mts.tv_sec;
    ~~~~~~~~~~ ^
../src/cmt_time.c:45:7: error: member reference type 'struct timespec' is not a pointer; did you mean to use '.'?
    tm->tv_nsec = mts.tv_nsec;
    ~~^~
      .
../src/cmt_time.c:45:17: error: expression is not assignable
    tm->tv_nsec = mts.tv_nsec;
    ~~~~~~~~~~~ ^
4 errors generated.
make[2]: *** [src/CMakeFiles/cmetrics-static.dir/cmt_time.c.o] Error 1
make[1]: *** [src/CMakeFiles/cmetrics-static.dir/all] Error 2
```