### PR TITLE
time: fixed CMT_HAVE_CLOCK_GET_TIME macro name 

### DIFF
--- a/src/cmt_time.c
+++ b/src/cmt_time.c
@@ -20,7 +20,7 @@
 #include <cmetrics/cmt_info.h>
 
 /* MacOS */
-#ifdef FLB_HAVE_CLOCK_GET_TIME
+#ifdef CMT_HAVE_CLOCK_GET_TIME
 #include <mach/clock.h>
 #include <mach/mach.h>
 #endif


### PR DESCRIPTION
Fix compilation errors on Darwin (using nixpkgs):

```
 [ 16%] Building C object lib/cmetrics/src/CMakeFiles/cmetrics-static.dir/cmt_time.c.o
 /tmp/nix-build-fluent-bit-1.8.9.drv-0/source/lib/cmetrics/src/cmt_time.c: In function 'cmt_time_now':
 /tmp/nix-build-fluent-bit-1.8.9.drv-0/source/lib/cmetrics/src/cmt_time.c:40:5: error: unknown type name 'clock_serv_t'
    40 |     clock_serv_t cclock;
       |     ^~~~~~~~~~~~
 /tmp/nix-build-fluent-bit-1.8.9.drv-0/source/lib/cmetrics/src/cmt_time.c:41:5: error: unknown type name 'mach_timespec_t'
    41 |     mach_timespec_t mts;
       |     ^~~~~~~~~~~~~~~
 /tmp/nix-build-fluent-bit-1.8.9.drv-0/source/lib/cmetrics/src/cmt_time.c:42:5: warning: implicit declaration of function 'host_get_clock_service' [8;;https://gcc.gnu.org/onlinedocs/gcc/Warning-Options.html#index-Wimplicit-function-declaration-Wimplicit-function-declaration8;;]
    42 |     host_get_clock_service(mach_host_self(), CALENDAR_CLOCK, &cclock);
       |     ^~~~~~~~~~~~~~~~~~~~~~
 /tmp/nix-build-fluent-bit-1.8.9.drv-0/source/lib/cmetrics/src/cmt_time.c:42:28: warning: implicit declaration of function 'mach_host_self' [8;;https://gcc.gnu.org/onlinedocs/gcc/Warning-Options.html#index-Wimplicit-function-declaration-Wimplicit-function-declaration8;;]
    42 |     host_get_clock_service(mach_host_self(), CALENDAR_CLOCK, &cclock);
       |                            ^~~~~~~~~~~~~~
 /tmp/nix-build-fluent-bit-1.8.9.drv-0/source/lib/cmetrics/src/cmt_time.c:42:46: error: 'CALENDAR_CLOCK' undeclared (first use in this function)
    42 |     host_get_clock_service(mach_host_self(), CALENDAR_CLOCK, &cclock);
       |                                              ^~~~~~~~~~~~~~
 /tmp/nix-build-fluent-bit-1.8.9.drv-0/source/lib/cmetrics/src/cmt_time.c:42:46: note: each undeclared identifier is reported only once for each function it appears in
 /tmp/nix-build-fluent-bit-1.8.9.drv-0/source/lib/cmetrics/src/cmt_time.c:43:5: warning: implicit declaration of function 'clock_get_time'; did you mean 'clock_gettime'? [8;;https://gcc.gnu.org/onlinedocs/gcc/Warning-Options.html#index-Wimplicit-function-declaration-Wimplicit-function-declaration8;;]
    43 |     clock_get_time(cclock, &mts);
       |     ^~~~~~~~~~~~~~
       |     clock_gettime
 make[2]: *** [lib/cmetrics/src/CMakeFiles/cmetrics-static.dir/build.make:174: lib/cmetrics/src/CMakeFiles/cmetrics-static.dir/cmt_time.c.o] Error 1
 make[1]: *** [CMakeFiles/Makefile2:2741: lib/cmetrics/src/CMakeFiles/cmetrics-static.dir/all] Error 2
```

Homebrew has been using the same patch for a while but looks like they never contributed it here: https://github.com/Homebrew/homebrew-core/commit/2493ff043d0a7db4aae51c5cf1c0c2edf5216dff