### PR TITLE
build: ignore version header

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *~
 build/*
 include/cmetrics/cmt_info.h
+include/cmetrics/cmt_version.h


### PR DESCRIPTION
This patch is to ignore auto generated header file `cmt_version.h`