### PR TITLE
workflows: added upload and auto-release creation

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  # Maintain dependencies for GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/packages.yaml
+++ b/.github/workflows/packages.yaml
@@ -1,9 +1,12 @@
+name: Build packages for master or a tagged release
+
 on:
   push:
     branches:
       - master
+    tags:
+      - "v*.*.*"
 
-name: Build packages for master
 jobs:
   build-distro-packages:
     name: build packages
@@ -26,3 +29,36 @@ jobs:
           name: ${{ matrix.format }}
           path: |
             ./*.${{matrix.format}}
+
+  release:
+    name: Create release and upload packages
+    needs: build-distro-packages
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Download all artefacts
+        uses: actions/download-artifact@v2
+        with:
+          path: artifacts/
+      
+      - name: Display structure of downloaded files
+        run: ls -R
+        working-directory: artifacts
+        shell: bash
+
+      - name: Unstable release on push to master to make it easier to download
+        uses: pyTooling/Actions/releaser@r0
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          tag: 'unstable'
+          files: |
+            artifacts/**/*
+
+      - name: Release on tag
+        uses: softprops/action-gh-release@v1
+        if: startsWith(github.ref, 'refs/tags/')
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          files: |
+            artifacts/**/*


### PR DESCRIPTION
Automatically creates a release now when a tag is pushed, the release will contain the RPM or DEB packages as well.
The URL for a release is much easier to consume.
Modified to create a special "unstable" release on every push that contains the built packages so you can have a fixed URL consuming latest.

Signed-off-by: Patrick Stephens <pat@calyptia.com>