### PR TITLE
workflows: update tag regex for release

### DIFF
--- a/.github/workflows/packages.yaml
+++ b/.github/workflows/packages.yaml
@@ -4,8 +4,9 @@ on:
   push:
     branches:
       - master
+    # Any tag starting with 'v'
     tags:
-      - "v*.*.*"
+      - v*
 
 jobs:
   build-distro-packages:
@@ -41,7 +42,7 @@ jobs:
         uses: actions/download-artifact@v2
         with:
           path: artifacts/
-      
+
       - name: Display structure of downloaded files
         run: ls -R
         working-directory: artifacts


### PR DESCRIPTION
Per comment on #59, ensure we only release on a v* tag.
Signed-off-by: Patrick Stephens <pat@calyptia.com>