### PR TITLE
workflows: quote the regex for tag detection

### DIFF
--- a/.github/workflows/packages.yaml
+++ b/.github/workflows/packages.yaml
@@ -6,7 +6,7 @@ on:
       - master
     # Any tag starting with 'v'
     tags:
-      - v*
+      - 'v*'
 
 jobs:
   build-distro-packages:

--- a/.github/workflows/packages.yaml
+++ b/.github/workflows/packages.yaml
@@ -7,6 +7,7 @@ on:
     # Any tag starting with 'v'
     tags:
       - 'v*'
+  workflow_dispatch:
 
 jobs:
   build-distro-packages:


### PR DESCRIPTION
Tried to trigger a release with a new tag but failed.
The regex needed quoting.
Added workflow dispatch so we can actually select a tag to create a release from as well manually.

Signed-off-by: Patrick Stephens <pat@calyptia.com>