### PR TITLE
Prometheus text format parser

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -40,6 +40,6 @@ jobs:
           echo "CC = $CC, CXX = $CXX"
           cmake -DCMT_TESTS=On .
           make all
-          make test
+          CTEST_OUTPUT_ON_FAILURE=1 make test
         env:
           CC: ${{ matrix.compiler }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,11 +36,14 @@ if(CMT_DEV)
   set(CMT_TESTS   Yes)
 endif()
 
+set(FLEX_BISON_GENERATED_DIR ${CMAKE_CURRENT_BINARY_DIR})
 # Include headers and dependency headers
 include_directories(
+  src
   include
   lib/monkey/include
   lib/xxHash-0.8.0/
+  ${FLEX_BISON_GENERATED_DIR}
   )
 
 # timespec_get() support
@@ -101,6 +104,13 @@ check_c_source_compiles("
      msgpack_sbuffer sbuf;
      return 0;
   }" CMT_HAVE_MSGPACK)
+
+find_package(FLEX)
+find_package(BISON)
+
+if(NOT FLEX_FOUND AND BISON_FOUND)
+  message(FATAL_ERROR "Both flex and bison are required for building cmetrics")
+endif()
 
 configure_file(
   "${PROJECT_SOURCE_DIR}/include/cmetrics/cmt_info.h.in"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,7 @@
 cmake_minimum_required(VERSION 2.8)
 project(cmetrics C)
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
 # Define macro to identify Windows system (without Cygwin)
 if(CMAKE_SYSTEM_NAME MATCHES "Windows")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -105,11 +105,11 @@ check_c_source_compiles("
      return 0;
   }" CMT_HAVE_MSGPACK)
 
-find_package(FLEX)
-find_package(BISON)
+find_package(FLEX 2)
+find_package(BISON 3)
 
-if(NOT FLEX_FOUND AND BISON_FOUND)
-  message(FATAL_ERROR "Both flex and bison are required for building cmetrics")
+if(FLEX_FOUND AND BISON_FOUND)
+    set(CMT_BUILD_PROMETHEUS_DECODER 1)
 endif()
 
 configure_file(

--- a/include/cmetrics/cmt_decode_prometheus.h
+++ b/include/cmetrics/cmt_decode_prometheus.h
@@ -20,12 +20,14 @@
 #ifndef CMT_DECODE_PROMETHEUS_H
 #define CMT_DECODE_PROMETHEUS_H
 
+#include "monkey/mk_core/mk_list.h"
 #include <cmetrics/cmetrics.h>
 
 #define CMT_DECODE_PROMETHEUS_SUCCESS                     0
 #define CMT_DECODE_PROMETHEUS_SYNTAX_ERROR                1
 #define CMT_DECODE_PROMETHEUS_ALLOCATION_ERROR           10
 #define CMT_DECODE_PROMETHEUS_PARSE_UNSUPPORTED_TYPE     20
+#define CMT_DECODE_PROMETHEUS_MAX_LABEL_COUNT_EXCEEDED   30
 
 // due to a bug in flex/bison code generation, this must be defined before
 // including the generated headers
@@ -43,6 +45,8 @@ struct cmt_decode_prometheus_context_sample {
     uint64_t timestamp;
     size_t label_count;
     cmt_sds_t label_values[CMT_DECODE_PROMETHEUS_MAX_LABEL_COUNT];
+
+    struct mk_list _head;
 };
 
 struct cmt_decode_prometheus_context_metric {
@@ -54,9 +58,7 @@ struct cmt_decode_prometheus_context_metric {
     cmt_sds_t docstring;
     size_t label_count;
     cmt_sds_t labels[CMT_DECODE_PROMETHEUS_MAX_LABEL_COUNT];
-    size_t sample_count;
-    size_t sample_count_start;
-    struct cmt_decode_prometheus_context_sample samples[50];
+    struct mk_list samples;
 };
 
 struct cmt_decode_prometheus_context {

--- a/include/cmetrics/cmt_decode_prometheus.h
+++ b/include/cmetrics/cmt_decode_prometheus.h
@@ -22,18 +22,10 @@
 
 #include <cmetrics/cmetrics.h>
 
-#define CMT_DECODE_PROMETHEUS_SUCCESS                    0
-#define CMT_DECODE_PROMETHEUS_INSUFFICIENT_DATA          1
-#define CMT_DECODE_PROMETHEUS_INVALID_ARGUMENT_ERROR     2
-#define CMT_DECODE_PROMETHEUS_ALLOCATION_ERROR           3
-#define CMT_DECODE_PROMETHEUS_CORRUPT_INPUT_DATA_ERROR   4
-#define CMT_DECODE_PROMETHEUS_CONSUME_ERROR              5
-#define CMT_DECODE_PROMETHEUS_ENGINE_ERROR               6
-#define CMT_DECODE_PROMETHEUS_PENDING_MAP_ENTRIES        7
-#define CMT_DECODE_PROMETHEUS_PENDING_ARRAY_ENTRIES      8
-#define CMT_DECODE_PROMETHEUS_UNEXPECTED_KEY_ERROR       9
-#define CMT_DECODE_PROMETHEUS_UNEXPECTED_DATA_TYPE_ERROR 10
-#define CMT_DECODE_PROMETHEUS_ERROR_CUTOFF               20
+#define CMT_DECODE_PROMETHEUS_SUCCESS                     0
+#define CMT_DECODE_PROMETHEUS_SYNTAX_ERROR                1
+#define CMT_DECODE_PROMETHEUS_ALLOCATION_ERROR           10
+#define CMT_DECODE_PROMETHEUS_PARSE_UNSUPPORTED_TYPE     20
 
 // due to a bug in flex/bison code generation, this must be defined before
 // including the generated headers
@@ -63,11 +55,14 @@ struct cmt_decode_prometheus_context_metric {
     size_t label_count;
     cmt_sds_t labels[CMT_DECODE_PROMETHEUS_MAX_LABEL_COUNT];
     size_t sample_count;
+    size_t sample_count_start;
     struct cmt_decode_prometheus_context_sample samples[50];
 };
 
 struct cmt_decode_prometheus_context {
     struct cmt *cmt;
+    char *errbuf;
+    size_t errbuf_size;
     int start_token;
     cmt_sds_t strbuf;
     struct cmt_decode_prometheus_context_metric metric;
@@ -85,7 +80,8 @@ int cmt_decode_prometheus_lex(YYSTYPE *yylval_param,
 #include "cmt_decode_prometheus_lexer.h"
 #endif
 
-int cmt_decode_prometheus_create(struct cmt **out_cmt, const char *in_buf);
+int cmt_decode_prometheus_create(struct cmt **out_cmt, const char *in_buf,
+         char *errbuf, size_t errbuf_size);
 void cmt_decode_prometheus_destroy(struct cmt *cmt);
 
 #endif

--- a/include/cmetrics/cmt_decode_prometheus.h
+++ b/include/cmetrics/cmt_decode_prometheus.h
@@ -28,6 +28,8 @@
 #define CMT_DECODE_PROMETHEUS_ALLOCATION_ERROR           10
 #define CMT_DECODE_PROMETHEUS_PARSE_UNSUPPORTED_TYPE     20
 #define CMT_DECODE_PROMETHEUS_MAX_LABEL_COUNT_EXCEEDED   30
+#define CMT_DECODE_PROMETHEUS_CMT_SET_ERROR              40
+#define CMT_DECODE_PROMETHEUS_CMT_CREATE_ERROR           50
 
 // due to a bug in flex/bison code generation, this must be defined before
 // including the generated headers
@@ -63,6 +65,7 @@ struct cmt_decode_prometheus_context_metric {
 
 struct cmt_decode_prometheus_context {
     struct cmt *cmt;
+    int errcode;
     char *errbuf;
     size_t errbuf_size;
     int start_token;

--- a/include/cmetrics/cmt_decode_prometheus.h
+++ b/include/cmetrics/cmt_decode_prometheus.h
@@ -1,0 +1,91 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*  CMetrics
+ *  ========
+ *  Copyright 2021 Eduardo Silva <eduardo@calyptia.com>
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#ifndef CMT_DECODE_PROMETHEUS_H
+#define CMT_DECODE_PROMETHEUS_H
+
+#include <cmetrics/cmetrics.h>
+
+#define CMT_DECODE_PROMETHEUS_SUCCESS                    0
+#define CMT_DECODE_PROMETHEUS_INSUFFICIENT_DATA          1
+#define CMT_DECODE_PROMETHEUS_INVALID_ARGUMENT_ERROR     2
+#define CMT_DECODE_PROMETHEUS_ALLOCATION_ERROR           3
+#define CMT_DECODE_PROMETHEUS_CORRUPT_INPUT_DATA_ERROR   4
+#define CMT_DECODE_PROMETHEUS_CONSUME_ERROR              5
+#define CMT_DECODE_PROMETHEUS_ENGINE_ERROR               6
+#define CMT_DECODE_PROMETHEUS_PENDING_MAP_ENTRIES        7
+#define CMT_DECODE_PROMETHEUS_PENDING_ARRAY_ENTRIES      8
+#define CMT_DECODE_PROMETHEUS_UNEXPECTED_KEY_ERROR       9
+#define CMT_DECODE_PROMETHEUS_UNEXPECTED_DATA_TYPE_ERROR 10
+#define CMT_DECODE_PROMETHEUS_ERROR_CUTOFF               20
+
+// due to a bug in flex/bison code generation, this must be defined before
+// including the generated headers
+#define YYSTYPE CMT_DECODE_PROMETHEUS_STYPE
+
+#define YY_DECL int yylex \
+               (YYSTYPE * yylval_param, \
+               void* yyscanner, \
+               struct cmt_decode_prometheus_context *context)
+
+#define CMT_DECODE_PROMETHEUS_MAX_LABEL_COUNT 128
+
+struct cmt_decode_prometheus_context_sample {
+    double value;
+    uint64_t timestamp;
+    size_t label_count;
+    cmt_sds_t label_values[CMT_DECODE_PROMETHEUS_MAX_LABEL_COUNT];
+};
+
+struct cmt_decode_prometheus_context_metric {
+    cmt_sds_t name_orig;
+    char *ns;
+    char *subsystem;
+    char *name;
+    int type;
+    cmt_sds_t docstring;
+    size_t label_count;
+    cmt_sds_t labels[CMT_DECODE_PROMETHEUS_MAX_LABEL_COUNT];
+    size_t sample_count;
+    struct cmt_decode_prometheus_context_sample samples[50];
+};
+
+struct cmt_decode_prometheus_context {
+    struct cmt *cmt;
+    int start_token;
+    cmt_sds_t strbuf;
+    struct cmt_decode_prometheus_context_metric metric;
+};
+
+#include "cmt_decode_prometheus_parser.h"
+
+int cmt_decode_prometheus_lex(YYSTYPE *yylval_param,
+                              void *yyscanner,
+                              struct cmt_decode_prometheus_context *context);
+
+#ifndef FLEX_SCANNER
+// lexer header should not be included in the generated lexer c file,
+// which defines FLEX_SCANNER
+#include "cmt_decode_prometheus_lexer.h"
+#endif
+
+int cmt_decode_prometheus_create(struct cmt **out_cmt, const char *in_buf);
+void cmt_decode_prometheus_destroy(struct cmt *cmt);
+
+#endif

--- a/include/cmetrics/cmt_decode_prometheus.h
+++ b/include/cmetrics/cmt_decode_prometheus.h
@@ -30,6 +30,8 @@
 #define CMT_DECODE_PROMETHEUS_MAX_LABEL_COUNT_EXCEEDED   30
 #define CMT_DECODE_PROMETHEUS_CMT_SET_ERROR              40
 #define CMT_DECODE_PROMETHEUS_CMT_CREATE_ERROR           50
+#define CMT_DECODE_PROMETHEUS_PARSE_VALUE_FAILED         60
+#define CMT_DECODE_PROMETHEUS_PARSE_TIMESTAMP_FAILED     70
 
 // due to a bug in flex/bison code generation, this must be defined before
 // including the generated headers
@@ -44,7 +46,7 @@
 
 struct cmt_decode_prometheus_context_sample {
     double value;
-    uint64_t timestamp;
+    int64_t timestamp;
     size_t label_count;
     cmt_sds_t label_values[CMT_DECODE_PROMETHEUS_MAX_LABEL_COUNT];
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,3 +1,12 @@
+flex_target(cmt_decode_prometheus_lexer cmt_decode_prometheus.l
+  "${FLEX_BISON_GENERATED_DIR}/cmt_decode_prometheus_lexer.c"
+  DEFINES_FILE "${FLEX_BISON_GENERATED_DIR}/cmt_decode_prometheus_lexer.h"
+  )
+bison_target(cmt_decode_prometheus_parser cmt_decode_prometheus.y
+  "${FLEX_BISON_GENERATED_DIR}/cmt_decode_prometheus_parser.c")
+add_flex_bison_dependency(cmt_decode_prometheus_lexer cmt_decode_prometheus_parser)
+
+
 set(src
   cmt_gauge.c
   cmt_counter.c
@@ -41,7 +50,11 @@ set(src
   )
 
 # Static Library
-add_library(cmetrics-static STATIC ${src})
+add_library(cmetrics-static STATIC
+  ${src}
+  ${FLEX_cmt_decode_prometheus_lexer_OUTPUTS}
+  ${BISON_cmt_decode_prometheus_parser_OUTPUTS}
+  )
 target_link_libraries(cmetrics-static xxhash mpack-static)
 
 # Install Library

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,10 +1,12 @@
-flex_target(cmt_decode_prometheus_lexer cmt_decode_prometheus.l
-  "${FLEX_BISON_GENERATED_DIR}/cmt_decode_prometheus_lexer.c"
-  DEFINES_FILE "${FLEX_BISON_GENERATED_DIR}/cmt_decode_prometheus_lexer.h"
-  )
-bison_target(cmt_decode_prometheus_parser cmt_decode_prometheus.y
-  "${FLEX_BISON_GENERATED_DIR}/cmt_decode_prometheus_parser.c")
-add_flex_bison_dependency(cmt_decode_prometheus_lexer cmt_decode_prometheus_parser)
+if (CMT_BUILD_PROMETHEUS_DECODER)
+    flex_target(cmt_decode_prometheus_lexer cmt_decode_prometheus.l
+        "${FLEX_BISON_GENERATED_DIR}/cmt_decode_prometheus_lexer.c"
+        DEFINES_FILE "${FLEX_BISON_GENERATED_DIR}/cmt_decode_prometheus_lexer.h"
+        )
+    bison_target(cmt_decode_prometheus_parser cmt_decode_prometheus.y
+        "${FLEX_BISON_GENERATED_DIR}/cmt_decode_prometheus_parser.c")
+    add_flex_bison_dependency(cmt_decode_prometheus_lexer cmt_decode_prometheus_parser)
+endif()
 
 
 set(src
@@ -49,12 +51,15 @@ set(src
   ${PLATFORM_SPECIFIC_ATOMIC_MODULE}
   )
 
+if (CMT_BUILD_PROMETHEUS_DECODER)
+    set(src ${src}
+        ${FLEX_cmt_decode_prometheus_lexer_OUTPUTS}
+        ${BISON_cmt_decode_prometheus_parser_OUTPUTS}
+        )
+endif()
+
 # Static Library
-add_library(cmetrics-static STATIC
-  ${src}
-  ${FLEX_cmt_decode_prometheus_lexer_OUTPUTS}
-  ${BISON_cmt_decode_prometheus_parser_OUTPUTS}
-  )
+add_library(cmetrics-static STATIC ${src})
 target_link_libraries(cmetrics-static xxhash mpack-static)
 
 # Install Library

--- a/src/cmt_decode_prometheus.c
+++ b/src/cmt_decode_prometheus.c
@@ -1,0 +1,280 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*  CMetrics
+ *  ========
+ *  Copyright 2021 Eduardo Silva <eduardo@calyptia.com>
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#include "cmetrics/cmetrics.h"
+#include "cmetrics/cmt_untyped.h"
+#include "monkey/mk_core/mk_list.h"
+#include <cmetrics/cmt_counter.h>
+#include <cmetrics/cmt_sds.h>
+#include <cmetrics/cmt_decode_prometheus.h>
+#include <stdint.h>
+
+int cmt_decode_prometheus_create(struct cmt **out_cmt, const char *in_buf)
+{
+    yyscan_t scanner;
+    YY_BUFFER_STATE buf;
+    struct cmt *cmt;
+    struct cmt_decode_prometheus_context context;
+    int result;
+
+    cmt = cmt_create();
+
+    if (cmt == NULL) {
+        return CMT_DECODE_PROMETHEUS_ALLOCATION_ERROR;
+    }
+
+    memset(&context, 0, sizeof(context));
+    context.cmt = cmt;
+    cmt_decode_prometheus_lex_init(&scanner);
+    buf = cmt_decode_prometheus__scan_string(in_buf, scanner);
+    if (!buf) {
+        cmt_destroy(cmt);
+        return CMT_DECODE_PROMETHEUS_ALLOCATION_ERROR;
+    }
+
+    result = cmt_decode_prometheus_parse(scanner, &context);
+
+    if (result == 0) {
+        *out_cmt = cmt;
+    }
+    else {
+        cmt_destroy(cmt);
+    }
+
+    cmt_decode_prometheus__delete_buffer(buf, scanner);
+    cmt_decode_prometheus_lex_destroy(scanner);
+
+    return result;
+}
+
+void cmt_decode_prometheus_destroy(struct cmt *cmt)
+{
+    cmt_destroy(cmt);
+}
+
+static int split_metric_name(cmt_sds_t metric_name, char **ns,
+        char **subsystem, char **name)
+{
+    // split the name
+    *ns = strdup(metric_name);
+    if (!*ns) {
+        return CMT_DECODE_PROMETHEUS_ALLOCATION_ERROR;
+    }
+    *subsystem = strchr(*ns, '_');
+    if (!subsystem) {
+        *name = metric_name;
+        *ns = NULL;
+    }
+    else {
+        **subsystem = 0;  // split
+        (*subsystem)++;
+        *name = strchr(*subsystem, '_');
+        if (!(*name)) {
+            *name = *subsystem;
+            *subsystem = NULL;
+        }
+        else {
+            **name = 0;
+            (*name)++;
+        }
+    }
+    return 0;
+}
+
+static int add_metric_counter(struct cmt_decode_prometheus_context *context)
+{
+    int i;
+    size_t label_count;
+    struct cmt_counter *c;
+
+    c = cmt_counter_create(context->cmt,
+            context->metric.ns,
+            context->metric.subsystem,
+            context->metric.name,
+            context->metric.docstring,
+            context->metric.label_count,
+            context->metric.labels);
+
+
+    for (i = 0; i < context->metric.sample_count; i++) {
+        label_count = context->metric.samples[i].label_count;
+        cmt_counter_set(c,
+                context->metric.samples[i].timestamp,
+                context->metric.samples[i].value,
+                label_count,
+                label_count ? context->metric.samples[i].label_values : NULL);
+    }
+
+    return 0;
+}
+
+static int add_metric_untyped(struct cmt_decode_prometheus_context *context)
+{
+    int i;
+    size_t label_count;
+    struct cmt_untyped *c;
+
+    c = cmt_untyped_create(context->cmt,
+            context->metric.ns,
+            context->metric.subsystem,
+            context->metric.name,
+            context->metric.docstring ? context->metric.docstring : "(no information)",
+            context->metric.label_count,
+            context->metric.labels);
+
+
+    for (i = 0; i < context->metric.sample_count; i++) {
+        label_count = context->metric.samples[i].label_count;
+        cmt_untyped_set(c,
+                context->metric.samples[i].timestamp,
+                context->metric.samples[i].value,
+                label_count,
+                label_count ? context->metric.samples[i].label_values : NULL);
+    }
+
+    return 0;
+}
+
+static int finish_metric(struct cmt_decode_prometheus_context *context)
+{
+    int i;
+    int j;
+    int rv;
+
+    switch (context->metric.type) {
+        case COUNTER:
+            rv = add_metric_counter(context);
+            break;
+        default:
+            rv = add_metric_untyped(context);
+            break;
+    }
+
+    // after a metric is parsed, we free all allocated strings and reset the context
+    for (i = 0; i < context->metric.sample_count; i++) {
+        for (j = 0; j < context->metric.samples[i].label_count; j++) {
+            cmt_sds_destroy(context->metric.samples[i].label_values[j]);
+        }
+    }
+    for (i = 0; i < context->metric.label_count; i++) {
+        cmt_sds_destroy(context->metric.labels[i]);
+    }
+    free(context->metric.ns);
+    cmt_sds_destroy(context->metric.name_orig);
+    cmt_sds_destroy(context->metric.docstring);
+    memset(&context->metric,
+            0,
+            sizeof(struct cmt_decode_prometheus_context_metric));
+
+    return rv;
+}
+
+static int parse_metric_name(
+        struct cmt_decode_prometheus_context *context,
+        cmt_sds_t metric_name)
+{
+    int ret = 0;
+
+    if (context->metric.name_orig) {
+        if (strcmp(context->metric.name_orig, metric_name)) {
+            // new metric name means the current metric is finished
+            ret = finish_metric(context);
+        }
+        else {
+            // same metric with name already allocated, destroy and return
+            cmt_sds_destroy(metric_name);
+            return ret;
+        }
+    }
+
+    if (!ret) {
+        context->metric.name_orig = metric_name;
+        ret = split_metric_name(metric_name,
+                &(context->metric.ns),
+                &(context->metric.subsystem),
+                &(context->metric.name));
+    }
+
+    return ret;
+}
+
+static int parse_label(
+        struct cmt_decode_prometheus_context *context,
+        cmt_sds_t name, cmt_sds_t value)
+{
+    int sindex;
+    int lindex;
+    int i;
+    cmt_sds_t label;
+
+    if (context->metric.label_count >= CMT_DECODE_PROMETHEUS_MAX_LABEL_COUNT) {
+        return -1;
+    }
+
+    // check if the label is already registered
+    for (i = 0; i < context->metric.label_count; i++) {
+        if (!strcmp(name, context->metric.labels[i])) {
+            // found, free the name memory and use the existing one
+            cmt_sds_destroy(name);
+            name = context->metric.labels[i];
+            break;
+        }
+    }
+    if (i == context->metric.label_count) {
+        // didn't found the label, add it now
+        context->metric.labels[i] = name;
+        context->metric.label_count++;
+    }
+
+    sindex = context->metric.sample_count;
+    // Uncomment the following two lines when cmetrics support the following usage:
+    //
+    //     struct cmt *cmt = cmt_create();
+    //     struct cmt_counter *c = cmt_counter_create(cmt, "metric", "name", "total", "Some metric description", 4, (char *[]) {"a", "b", "c", "d"});
+    //     cmt_counter_set(c, 0, 5, 4, (char *[]) { "0", "1", NULL, NULL });
+    //     cmt_counter_set(c, 0, 7, 4, (char *[]) { NULL, NULL, "2", "3" });
+    //
+    // context->metric.samples[sample_index].label_values[i] = value;
+    lindex = context->metric.samples[sindex].label_count;
+    context->metric.samples[sindex].label_values[lindex] = value;
+    context->metric.samples[sindex].label_count++;
+    return 0;
+}
+
+static void parse_sample(
+        struct cmt_decode_prometheus_context *context,
+        double value,
+        uint64_t timestamp)
+{
+    size_t index = context->metric.sample_count;
+    context->metric.samples[index].value = value;
+    // prometheus text format metrics are in milliseconds, while cmetrics is in
+    // nanoseconds, so multiply by 10e5
+    context->metric.samples[index].timestamp = timestamp * 10e5;
+    context->metric.sample_count++;
+}
+
+// called automatically by the generated parser code on error
+static int cmt_decode_prometheus_error(void *yyscanner,
+                                       struct cmt_decode_prometheus_context *context,
+                                       const char *msg)
+{
+    fprintf(stderr, "%s\n", msg);
+    return 0;
+}

--- a/src/cmt_decode_prometheus.c
+++ b/src/cmt_decode_prometheus.c
@@ -453,28 +453,12 @@ static int parse_value(char *in, double *out)
 {
     char *end;
     double val;
-    int i;
-    size_t len = strlen(in);
-
-    // convert the string to lowercase to simplify parsing infinity/nan
-    for (i = 0; i < len; i++) {
-        in[i] = tolower(in[i]);
+    errno = 0;
+    val = strtod(in, &end);
+    if (end == in || *end != 0 || errno) {
+        return -1;
     }
-
-    if (len > 1 && (!strcmp(in, "inf") || !strcmp(in + 1, "inf"))) {
-        *out = in[0] == '-' ? -INFINITY : INFINITY;
-    }
-    else if (len > 1 && !strcmp(in, "nan")) { 
-        *out = NAN;
-    }
-    else {
-        errno = 0;
-        val = strtod(in, &end);
-        if (end == in || *end != 0 || errno) {
-            return -1;
-        }
-        *out = val;
-    }
+    *out = val;
     return 0;
 }
 

--- a/src/cmt_decode_prometheus.c
+++ b/src/cmt_decode_prometheus.c
@@ -355,6 +355,8 @@ static int parse_label(
     struct cmt_decode_prometheus_context_sample *sample;
 
     if (context->metric.label_count >= CMT_DECODE_PROMETHEUS_MAX_LABEL_COUNT) {
+        cmt_sds_destroy(name);
+        cmt_sds_destroy(value);
         return report_error(context,
                 CMT_DECODE_PROMETHEUS_MAX_LABEL_COUNT_EXCEEDED,
                 "maximum number of labels exceeded");

--- a/src/cmt_decode_prometheus.l
+++ b/src/cmt_decode_prometheus.l
@@ -171,12 +171,17 @@
     return QUOTED;
 }
 
+[+-]?(?i:(INF|NAN)) {
+    strncpy(yylval->numstr, yytext, sizeof(yylval->numstr) - 1);
+    return INFNAN;
+}
+
 [a-zA-Z_][a-zA-Z_0-9]*  {
     yylval->str = cmt_sds_create(yytext);
     return IDENTIFIER;
 }
 
-[0-9.eE+-]+|[+-](?i:INF|NAN) {
+[0-9.eE+-]+ {
     strncpy(yylval->numstr, yytext, sizeof(yylval->numstr) - 1);
     return NUMSTR;
 }

--- a/src/cmt_decode_prometheus.l
+++ b/src/cmt_decode_prometheus.l
@@ -2,6 +2,7 @@
 
 %option reentrant bison-bridge
 %option noyywrap nounput noinput
+%option nodefault
 
 %{
 
@@ -65,6 +66,10 @@
     // will prioritize the two rules above this one since they have longer
     // matches.
     BEGIN(COMMENT);
+}
+
+<COMMENT>[^\n]+ {
+    // ignore
 }
 
 <HELPTAG,TYPETAG>[^ \t]+ {

--- a/src/cmt_decode_prometheus.l
+++ b/src/cmt_decode_prometheus.l
@@ -176,7 +176,7 @@
     return IDENTIFIER;
 }
 
-[0-9.eE+-]+ {
+[0-9.eE+-]+|[+-](?i:INF|NAN) {
     strncpy(yylval->numstr, yytext, sizeof(yylval->numstr) - 1);
     return NUMSTR;
 }

--- a/src/cmt_decode_prometheus.l
+++ b/src/cmt_decode_prometheus.l
@@ -1,0 +1,191 @@
+%option prefix="cmt_decode_prometheus_"
+
+%option reentrant bison-bridge
+%option noyywrap nounput noinput
+
+%{
+
+#include <cmetrics/cmt_decode_prometheus.h>
+
+#define STRBUF_RET \
+    yylval->str = context->strbuf; \
+    context->strbuf = NULL
+
+%}
+
+/* here we define some states that allow us to create rules only
+   matched in certain situations */
+
+%x INQUOTE HELPTAG INHELPTAG TYPETAG INTYPETAG COMMENT COMMENT_START
+
+%%
+
+%{
+    if (context->start_token) {
+        int t = context->start_token;
+        context->start_token = 0;
+        return t;
+    }
+%}
+
+<*>\r\n|\n {
+    int top_state = YYSTATE;
+    // We always return to the INITIAL state on a linefeed, no matter which
+    // state we are on (the "<*>" means this rule is applied on every state)
+    BEGIN(INITIAL);
+    if (top_state == INHELPTAG) {
+        // But if we were on the INHELPTAG state, we return everything collected
+        // in strbuf
+        STRBUF_RET;
+        return METRIC_DOC;
+    }
+}
+
+^[ ]*#[ ]* {
+    // Lines with "#" as the first non-whitespace character begin a comment
+    // unless the first token is either HELP or TYPE. To handle this ambiguity,
+    // we enter the COMMENT_START state, which contains rules for selecting 
+    // if this is a HELP/TYPE tag or just a normal comment
+    BEGIN(COMMENT_START);
+}
+
+<COMMENT_START>HELP[ \t]+ {
+    // Begin a help tag
+    BEGIN(HELPTAG);
+}
+
+<COMMENT_START>TYPE[ \t]+ {
+    // Begin a type tag
+    BEGIN(TYPETAG);
+}
+
+<COMMENT_START>[^\n] {
+    // Any character that is not a newline begins the COMMENT state where
+    // everything is ignored until the next linefeed. This works because flex
+    // will prioritize the two rules above this one since they have longer
+    // matches.
+    BEGIN(COMMENT);
+}
+
+<HELPTAG,TYPETAG>[^ \t]+ {
+    // The next token will be the metric name
+    yylval->str = cmt_sds_create(yytext);
+    return YYSTATE == HELPTAG ? HELP : TYPE;
+}
+
+<HELPTAG,TYPETAG>[ \t]* {
+    // Every whitespace after the metric name is ignored
+    if (YYSTATE == HELPTAG) {
+        // For HELPTAG we enter the INHELPTAG start condition which we will use to
+        // read everything until the end of line into context->strbuf. We enter a
+        // separate start condition for this to handle "\\" and "\n" escapes
+        // more easily.
+        BEGIN(INHELPTAG);
+        context->strbuf = sds_alloc(256);
+    }
+    else {
+        // For TYPETAG we enter INTYPETAG start condition to check only valid
+        // metric types are accepted. This prevents us from having to do
+        // manual validation later.
+        BEGIN(INTYPETAG);
+    }
+}
+
+<INHELPTAG><<EOF>> {
+    // Handle EOF when in the INHELPTAG state by returning the buffered docstring.
+    // While this is not strictly necessary, it makes easier unit testing the
+    // lexer
+    BEGIN(INITIAL);
+    STRBUF_RET;
+    return METRIC_DOC;
+}
+
+<INHELPTAG>\\n {
+    // Process linefeed escape sequence
+    context->strbuf = cmt_sds_cat(context->strbuf, "\n", 1);
+}
+
+<INHELPTAG>\\\\ {
+    // Process backslack escape sequence
+    context->strbuf = cmt_sds_cat(context->strbuf, "\\", 1);
+}
+
+<INHELPTAG>[^\r\n\\]+ {
+    // Put everything that is not a backslash or a line feed into strbuf
+    context->strbuf = cmt_sds_cat(context->strbuf, yytext, yyleng);
+}
+
+<INTYPETAG>counter {
+    return COUNTER;
+}
+
+<INTYPETAG>gauge {
+    return GAUGE;
+}
+
+<INTYPETAG>summary {
+    return SUMMARY;
+}
+
+<INTYPETAG>untyped {
+    return UNTYPED;
+}
+
+<INTYPETAG>histogram {
+    return HISTOGRAM;
+}
+
+<INTYPETAG,INITIAL>[ \t]+ {
+    /* ignore whitespace */
+}
+
+["] {
+    BEGIN(INQUOTE);
+    context->strbuf = sds_alloc(256);
+}
+
+<INQUOTE>[\\]["] {
+    context->strbuf = cmt_sds_cat(context->strbuf, "\"", 1);
+}
+
+<INQUOTE>\\n {
+    context->strbuf = cmt_sds_cat(context->strbuf, "\n", 1);
+}
+
+<INQUOTE>\\\\ {
+    context->strbuf = cmt_sds_cat(context->strbuf, "\\", 1);
+}
+
+<INQUOTE>[^\r\n\\"]+ {
+    context->strbuf = cmt_sds_cat(context->strbuf, yytext, yyleng);
+}
+
+<INQUOTE>["] {
+    BEGIN(INITIAL);
+    STRBUF_RET;
+    return QUOTED;
+}
+
+[a-zA-Z_][a-zA-Z_0-9]*  {
+    yylval->str = cmt_sds_create(yytext);
+    return IDENTIFIER;
+}
+
+[0-9]+ {
+    yylval->integer = strtoll(yytext, NULL, 10);
+    return INTEGER;
+}
+
+[0-9]*[0-9.][0-9]*([Ee][-+]?[0-9]+)? {
+    // floating point is defined later so that integers have a preference
+    yylval->fpoint = atof(yytext);
+    return FPOINT;
+}
+
+. {
+    // Catch all workaround to avoid having to define token types for every
+    // possible delimiter. We simply return the character to the parser.
+    return *yytext;
+}
+
+%%

--- a/src/cmt_decode_prometheus.l
+++ b/src/cmt_decode_prometheus.l
@@ -176,15 +176,9 @@
     return IDENTIFIER;
 }
 
-[0-9]+ {
-    yylval->integer = strtoll(yytext, NULL, 10);
-    return INTEGER;
-}
-
-[0-9]*[0-9.][0-9]*([Ee][-+]?[0-9]+)? {
-    // floating point is defined later so that integers have a preference
-    yylval->fpoint = atof(yytext);
-    return FPOINT;
+[0-9.eE+-]+ {
+    strncpy(yylval->numstr, yytext, sizeof(yylval->numstr) - 1);
+    return NUMSTR;
 }
 
 . {

--- a/src/cmt_decode_prometheus.y
+++ b/src/cmt_decode_prometheus.y
@@ -1,0 +1,139 @@
+%define api.pure true
+%define api.prefix {cmt_decode_prometheus_}
+%define parse.error verbose
+
+%param {void *yyscanner}
+%param {struct cmt_decode_prometheus_context *context}
+
+%{
+// we inline cmt_decode_prometheus.c which contains all the actions to avoid
+// having to export a bunch of symbols that are only used by the generated
+// parser code
+#include "cmt_decode_prometheus.c"
+%}
+
+%union {
+    cmt_sds_t str;
+    double fpoint;
+    long long integer;
+}
+
+%token '=' '{' '}' ','
+%token <str> IDENTIFIER QUOTED HELP TYPE METRIC_DOC
+%token COUNTER GAUGE SUMMARY UNTYPED HISTOGRAM
+%token START_HEADER START_LABELS START_SAMPLES
+%token <fpoint> FPOINT
+%token <integer> INTEGER
+
+%type <integer> metric_type
+
+%start start;
+
+%%
+
+start:
+    START_HEADER header
+  | START_LABELS labels
+  | START_SAMPLES samples
+  | metric {
+    if (finish_metric(context)) {
+        YYABORT;
+    }
+  }
+;
+
+metrics:
+    metrics metric
+  | metric
+;
+
+metric:
+    header samples
+  | samples
+;
+
+header:
+    help type
+  | help
+  | type help
+  | type
+;
+
+help:
+    HELP METRIC_DOC {
+        parse_metric_name(context, $1);
+        context->metric.docstring = $2;
+    }
+;
+
+type:
+    TYPE metric_type {
+        parse_metric_name(context, $1);
+        context->metric.type = $2;
+    }
+;
+
+metric_type:
+    COUNTER { $$ = COUNTER; }
+  | GAUGE { $$ = GAUGE; }
+  | SUMMARY { $$ = SUMMARY; }
+  | UNTYPED { $$ = UNTYPED; }
+  | HISTOGRAM { $$ = HISTOGRAM; }
+;
+
+samples:
+    samples sample
+  | sample
+;
+
+sample:
+    IDENTIFIER { 
+        parse_metric_name(context, $1);
+    } sample_data
+;
+
+sample_data:
+    '{' labels '}' values
+  | values
+;
+
+labels:
+    labellist ','
+  | labellist
+;
+
+labellist:
+    labellist ',' label
+  | label
+;
+
+label:
+    IDENTIFIER '=' QUOTED {
+        if (parse_label(context, $1, $3)) {
+            YYABORT;
+        }
+    }
+;
+
+values:
+    FPOINT INTEGER {
+        parse_sample(context, $1, $2);
+    }
+  | FPOINT FPOINT {
+        parse_sample(context, $1, $2);
+    }
+  | INTEGER FPOINT {
+        parse_sample(context, $1, $2);
+    }
+  | INTEGER INTEGER {
+        parse_sample(context, $1, $2);
+    }
+  | INTEGER {
+        parse_sample(context, $1, 0);
+    }
+  | FPOINT {
+        parse_sample(context, $1, 0);
+    }
+;
+
+%%

--- a/src/cmt_decode_prometheus.y
+++ b/src/cmt_decode_prometheus.y
@@ -92,8 +92,13 @@ samples:
 
 sample:
     IDENTIFIER { 
-        parse_metric_name(context, $1); $1 = NULL;
-        sample_start(context);
+        if (parse_metric_name(context, $1)) {
+            YYABORT;
+        }
+        $1 = NULL;
+        if (sample_start(context)) {
+            YYABORT;
+        }
     } sample_data
 ;
 
@@ -122,12 +127,6 @@ label:
 
 values:
     FPOINT INTEGER {
-        parse_sample(context, $1, $2);
-    }
-  | FPOINT FPOINT {
-        parse_sample(context, $1, $2);
-    }
-  | INTEGER FPOINT {
         parse_sample(context, $1, $2);
     }
   | INTEGER INTEGER {

--- a/src/cmt_decode_prometheus.y
+++ b/src/cmt_decode_prometheus.y
@@ -22,9 +22,10 @@
 %token <str> IDENTIFIER QUOTED HELP TYPE METRIC_DOC
 %token COUNTER GAUGE SUMMARY UNTYPED HISTOGRAM
 %token START_HEADER START_LABELS START_SAMPLES
-%token <numstr> NUMSTR
+%token <numstr> NUMSTR INFNAN
 
 %type <integer> metric_type
+%type <numstr> value
 
 %destructor {
     cmt_sds_destroy($$);
@@ -125,16 +126,20 @@ label:
 ;
 
 values:
-    NUMSTR NUMSTR {
+    value value {
         if (parse_sample(context, $1, $2)) {
             YYABORT;
         }
     }
-  | NUMSTR {
+  | value {
         if (parse_sample(context, $1, "0")) {
             YYABORT;
         }
     }
+;
+
+value:
+    NUMSTR | INFNAN
 ;
 
 %%

--- a/src/cmt_decode_prometheus.y
+++ b/src/cmt_decode_prometheus.y
@@ -27,6 +27,10 @@
 
 %type <integer> metric_type
 
+%destructor {
+    cmt_sds_destroy($$);
+} <str>
+
 %start start;
 
 %%
@@ -88,7 +92,7 @@ samples:
 
 sample:
     IDENTIFIER { 
-        parse_metric_name(context, $1);
+        parse_metric_name(context, $1); $1 = NULL;
     } sample_data
 ;
 

--- a/src/cmt_decode_prometheus.y
+++ b/src/cmt_decode_prometheus.y
@@ -39,7 +39,7 @@ start:
     START_HEADER header
   | START_LABELS labels
   | START_SAMPLES samples
-  | metric {
+  | metrics {
     if (finish_metric(context)) {
         YYABORT;
     }

--- a/src/cmt_decode_prometheus.y
+++ b/src/cmt_decode_prometheus.y
@@ -14,16 +14,15 @@
 
 %union {
     cmt_sds_t str;
-    double fpoint;
-    long long integer;
+    char numstr[64];
+    int integer;
 }
 
 %token '=' '{' '}' ','
 %token <str> IDENTIFIER QUOTED HELP TYPE METRIC_DOC
 %token COUNTER GAUGE SUMMARY UNTYPED HISTOGRAM
 %token START_HEADER START_LABELS START_SAMPLES
-%token <fpoint> FPOINT
-%token <integer> INTEGER
+%token <numstr> NUMSTR
 
 %type <integer> metric_type
 
@@ -126,17 +125,15 @@ label:
 ;
 
 values:
-    FPOINT INTEGER {
-        parse_sample(context, $1, $2);
+    NUMSTR NUMSTR {
+        if (parse_sample(context, $1, $2)) {
+            YYABORT;
+        }
     }
-  | INTEGER INTEGER {
-        parse_sample(context, $1, $2);
-    }
-  | INTEGER {
-        parse_sample(context, $1, 0);
-    }
-  | FPOINT {
-        parse_sample(context, $1, 0);
+  | NUMSTR {
+        if (parse_sample(context, $1, "0")) {
+            YYABORT;
+        }
     }
 ;
 

--- a/src/cmt_decode_prometheus.y
+++ b/src/cmt_decode_prometheus.y
@@ -93,6 +93,7 @@ samples:
 sample:
     IDENTIFIER { 
         parse_metric_name(context, $1); $1 = NULL;
+        sample_start(context);
     } sample_data
 ;
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -4,6 +4,8 @@ set(UNIT_TESTS_FILES
   counter.c
   untyped.c
   atomic_operations.c
+  prometheus_lexer.c
+  prometheus_parser.c
   encoding.c
   cat.c
   issues.c

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -4,12 +4,17 @@ set(UNIT_TESTS_FILES
   counter.c
   untyped.c
   atomic_operations.c
-  prometheus_lexer.c
-  prometheus_parser.c
   encoding.c
   cat.c
   issues.c
   )
+
+if (CMT_BUILD_PROMETHEUS_DECODER)
+    set(UNIT_TESTS_FILES
+        ${UNIT_TESTS_FILES}
+        prometheus_lexer.c
+        prometheus_parser.c)
+endif()
 
 # Prepare list of unit tests
 foreach(source_file ${UNIT_TESTS_FILES})

--- a/tests/prometheus_lexer.c
+++ b/tests/prometheus_lexer.c
@@ -1,0 +1,219 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*  CMetrics
+ *  ========
+ *  Copyright 2021 Eduardo Silva <eduardo@calyptia.com>
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#include <cmetrics/cmetrics.h>
+#include <cmetrics/cmt_counter.h>
+#include <cmetrics/cmt_decode_prometheus.h>
+#include <cmetrics/cmt_encode_prometheus_remote_write.h>
+#include <stdio.h>
+
+#include "cmetrics/cmt_sds.h"
+#include "cmt_decode_prometheus_parser.h"
+#include "cmt_tests.h"
+
+struct fixture {
+    yyscan_t scanner;
+    YY_BUFFER_STATE buf;
+    YYSTYPE lval;
+    struct cmt_decode_prometheus_context context;
+    const char *text;
+};
+
+struct fixture *init(const char *test)
+{
+    struct fixture *f = malloc(sizeof(*f));
+    memset(f, 0, sizeof(*f));
+    cmt_decode_prometheus_lex_init(&f->scanner);
+    f->buf = cmt_decode_prometheus__scan_string(test, f->scanner);
+    return f;
+}
+
+void destroy(struct fixture *f)
+{
+    cmt_decode_prometheus__delete_buffer(f->buf, f->scanner);
+    cmt_decode_prometheus_lex_destroy(f->scanner);
+    free(f);
+}
+
+int lex(struct fixture *f)
+{
+    return cmt_decode_prometheus_lex(&f->lval, f->scanner, &(f->context));
+}
+
+void test_comment()
+{
+    struct fixture *f = init("# this is just a comment");
+    TEST_CHECK(lex(f) == 0);  // 0 means EOF
+    destroy(f);
+}
+
+void test_help()
+{
+    struct fixture *f = init("# HELP cmt_labels_test Static \\\\labels\\n test");
+
+    TEST_CHECK(lex(f) == HELP);
+    TEST_CHECK(strcmp(f->lval.str, "cmt_labels_test") == 0);
+    cmt_sds_destroy(f->lval.str);
+
+    TEST_CHECK(lex(f) == METRIC_DOC);
+    TEST_CHECK(strcmp(f->lval.str, "Static \\labels\n test") == 0);
+    cmt_sds_destroy(f->lval.str);
+
+    destroy(f);
+
+    f = init("# HELP cmt_labels_test Static \\\\labels\\n test\n");
+
+    TEST_CHECK(lex(f) == HELP);
+    TEST_CHECK(strcmp(f->lval.str, "cmt_labels_test") == 0);
+    cmt_sds_destroy(f->lval.str);
+
+    TEST_CHECK(lex(f) == METRIC_DOC);
+    TEST_CHECK(strcmp(f->lval.str, "Static \\labels\n test") == 0);
+    cmt_sds_destroy(f->lval.str);
+
+    destroy(f);
+}
+
+void test_type()
+{
+    struct fixture *f = init("# TYPE metric_name gauge");
+
+    TEST_CHECK(lex(f) == TYPE);
+    TEST_CHECK(strcmp(f->lval.str, "metric_name") == 0);
+    cmt_sds_destroy(f->lval.str);
+
+    TEST_CHECK(lex(f) == GAUGE);
+
+    destroy(f);
+}
+
+void test_simple()
+{
+    struct fixture *f = init(
+            "# HELP cmt_labels_test Static labels test\n"
+            "# TYPE cmt_labels_test counter\n"
+            "cmt_labels_test 1 0\n"
+            "metric2{host=\"calyptia.com\",app=\"cmetrics \\n \\\\ \\\"\"} 2.5 0\n"
+            "# HELP metric1 Second HELP tag\n"
+            "metric1{escapes=\"\\n \\\\ \\\"\"} 4.12 5\n"
+            );
+
+    TEST_CHECK(lex(f) == HELP);
+    TEST_CHECK(strcmp(f->lval.str, "cmt_labels_test") == 0);
+    cmt_sds_destroy(f->lval.str);
+
+    TEST_CHECK(lex(f) == METRIC_DOC);
+    TEST_CHECK(strcmp(f->lval.str, "Static labels test") == 0);
+    cmt_sds_destroy(f->lval.str);
+
+    TEST_CHECK(lex(f) == TYPE);
+    TEST_CHECK(strcmp(f->lval.str, "cmt_labels_test") == 0);
+    cmt_sds_destroy(f->lval.str);
+
+    TEST_CHECK(lex(f) == COUNTER);
+
+    TEST_CHECK(lex(f) == IDENTIFIER);
+    TEST_CHECK(strcmp(f->lval.str, "cmt_labels_test") == 0);
+    cmt_sds_destroy(f->lval.str);
+
+    TEST_CHECK(lex(f) == INTEGER);
+    TEST_CHECK(f->lval.integer == 1);
+
+    TEST_CHECK(lex(f) == INTEGER);
+    TEST_CHECK(f->lval.integer == 0);
+
+    TEST_CHECK(lex(f) == IDENTIFIER);
+    TEST_CHECK(strcmp(f->lval.str, "metric2") == 0);
+    cmt_sds_destroy(f->lval.str);
+
+    TEST_CHECK(lex(f) == '{');
+
+    TEST_CHECK(lex(f) == IDENTIFIER);
+    TEST_CHECK(strcmp(f->lval.str, "host") == 0);
+    cmt_sds_destroy(f->lval.str);
+
+    TEST_CHECK(lex(f) == '=');
+
+    TEST_CHECK(lex(f) == QUOTED);
+    TEST_CHECK(strcmp(f->lval.str, "calyptia.com") == 0);
+    cmt_sds_destroy(f->lval.str);
+
+    TEST_CHECK(lex(f) == ',');
+
+    TEST_CHECK(lex(f) == IDENTIFIER);
+    TEST_CHECK(strcmp(f->lval.str, "app") == 0);
+    cmt_sds_destroy(f->lval.str);
+
+    TEST_CHECK(lex(f) == '=');
+
+    TEST_CHECK(lex(f) == QUOTED);
+    TEST_CHECK(strcmp(f->lval.str, "cmetrics \n \\ \"") == 0);
+    cmt_sds_destroy(f->lval.str);
+
+    TEST_CHECK(lex(f) == '}');
+
+    TEST_CHECK(lex(f) == FPOINT);
+    TEST_CHECK(f->lval.fpoint == 2.5);
+
+    TEST_CHECK(lex(f) == INTEGER);
+    TEST_CHECK(f->lval.fpoint == 0);
+
+    TEST_CHECK(lex(f) == HELP);
+    TEST_CHECK(strcmp(f->lval.str, "metric1") == 0);
+    cmt_sds_destroy(f->lval.str);
+
+    TEST_CHECK(lex(f) == METRIC_DOC);
+    TEST_CHECK(strcmp(f->lval.str, "Second HELP tag") == 0);
+    cmt_sds_destroy(f->lval.str);
+
+    TEST_CHECK(lex(f) == IDENTIFIER);
+    TEST_CHECK(strcmp(f->lval.str, "metric1") == 0);
+    cmt_sds_destroy(f->lval.str);
+
+    TEST_CHECK(lex(f) == '{');
+
+    TEST_CHECK(lex(f) == IDENTIFIER);
+    TEST_CHECK(strcmp(f->lval.str, "escapes") == 0);
+    cmt_sds_destroy(f->lval.str);
+
+    TEST_CHECK(lex(f) == '=');
+
+    TEST_CHECK(lex(f) == QUOTED);
+    TEST_CHECK(strcmp(f->lval.str, "\n \\ \"") == 0);
+    cmt_sds_destroy(f->lval.str);
+
+    TEST_CHECK(lex(f) == '}');
+
+    TEST_CHECK(lex(f) == FPOINT);
+    TEST_CHECK(f->lval.fpoint == 4.12);
+
+    TEST_CHECK(lex(f) == INTEGER);
+    TEST_CHECK(f->lval.integer == 5);
+
+    destroy(f);
+}
+
+
+TEST_LIST = {
+    {"test_comment", test_comment},
+    {"test_help", test_help},
+    {"test_type", test_type},
+    {"test_simple", test_simple},
+    { 0 }
+};

--- a/tests/prometheus_lexer.c
+++ b/tests/prometheus_lexer.c
@@ -132,11 +132,11 @@ void test_simple()
     TEST_CHECK(strcmp(f->lval.str, "cmt_labels_test") == 0);
     cmt_sds_destroy(f->lval.str);
 
-    TEST_CHECK(lex(f) == INTEGER);
-    TEST_CHECK(f->lval.integer == 1);
+    TEST_CHECK(lex(f) == NUMSTR);
+    TEST_CHECK(strcmp(f->lval.numstr, "1") == 0);
 
-    TEST_CHECK(lex(f) == INTEGER);
-    TEST_CHECK(f->lval.integer == 0);
+    TEST_CHECK(lex(f) == NUMSTR);
+    TEST_CHECK(strcmp(f->lval.numstr, "0") == 0);
 
     TEST_CHECK(lex(f) == IDENTIFIER);
     TEST_CHECK(strcmp(f->lval.str, "metric2") == 0);
@@ -168,11 +168,11 @@ void test_simple()
 
     TEST_CHECK(lex(f) == '}');
 
-    TEST_CHECK(lex(f) == FPOINT);
-    TEST_CHECK(f->lval.fpoint == 2.5);
+    TEST_CHECK(lex(f) == NUMSTR);
+    TEST_CHECK(strcmp(f->lval.numstr, "2.5") == 0);
 
-    TEST_CHECK(lex(f) == INTEGER);
-    TEST_CHECK(f->lval.fpoint == 0);
+    TEST_CHECK(lex(f) == NUMSTR);
+    TEST_CHECK(strcmp(f->lval.numstr, "0") == 0);
 
     TEST_CHECK(lex(f) == HELP);
     TEST_CHECK(strcmp(f->lval.str, "metric1") == 0);
@@ -200,11 +200,11 @@ void test_simple()
 
     TEST_CHECK(lex(f) == '}');
 
-    TEST_CHECK(lex(f) == FPOINT);
-    TEST_CHECK(f->lval.fpoint == 4.12);
+    TEST_CHECK(lex(f) == NUMSTR);
+    TEST_CHECK(strcmp(f->lval.numstr, "4.12") == 0);
 
-    TEST_CHECK(lex(f) == INTEGER);
-    TEST_CHECK(f->lval.integer == 5);
+    TEST_CHECK(lex(f) == NUMSTR);
+    TEST_CHECK(strcmp(f->lval.numstr, "5") == 0);
 
     destroy(f);
 }

--- a/tests/prometheus_parser.c
+++ b/tests/prometheus_parser.c
@@ -1,0 +1,322 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*  CMetrics
+ *  ========
+ *  Copyright 2021 Eduardo Silva <eduardo@calyptia.com>
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#include <cmetrics/cmetrics.h>
+#include <cmetrics/cmt_decode_prometheus.h>
+#include <cmetrics/cmt_encode_prometheus.h>
+
+#include "cmetrics/cmt_counter.h"
+#include "cmetrics/cmt_sds.h"
+#include "cmt_decode_prometheus_parser.h"
+#include "cmt_tests.h"
+#include "lib/acutest/acutest.h"
+
+struct fixture {
+    yyscan_t scanner;
+    YY_BUFFER_STATE buf;
+    YYSTYPE lval;
+    struct cmt_decode_prometheus_context context;
+    const char *text;
+};
+
+struct fixture *init(int start_token, const char *test)
+{
+    cmt_initialize();
+    struct fixture *f = malloc(sizeof(*f));
+    memset(f, 0, sizeof(*f));
+    f->context.cmt = cmt_create();
+    f->context.start_token = start_token;
+    cmt_decode_prometheus_lex_init(&f->scanner);
+    f->buf = cmt_decode_prometheus__scan_string(test, f->scanner);
+    return f;
+}
+
+void destroy(struct fixture *f)
+{
+    cmt_decode_prometheus__delete_buffer(f->buf, f->scanner);
+    cmt_decode_prometheus_lex_destroy(f->scanner);
+    cmt_destroy(f->context.cmt);
+    free(f);
+}
+
+int parse(struct fixture *f)
+{
+    return cmt_decode_prometheus_parse(f->scanner, &f->context);
+}
+
+void test_header_help()
+{
+    struct fixture *f = init(START_HEADER,
+            "# HELP cmt_labels_test Static labels test\n"
+            );
+
+    TEST_CHECK(parse(f) == 0);
+
+    TEST_CHECK(strcmp(f->context.metric.ns, "cmt") == 0);
+    TEST_CHECK(strcmp(f->context.metric.subsystem, "labels") == 0);
+    TEST_CHECK(strcmp(f->context.metric.name, "test") == 0);
+    TEST_CHECK(strcmp(f->context.metric.docstring, "Static labels test") == 0);
+    TEST_CHECK(f->context.metric.type == 0);
+    cmt_sds_destroy(f->context.metric.name_orig);
+    cmt_sds_destroy(f->context.metric.docstring);
+    free(f->context.metric.ns);
+
+    destroy(f);
+}
+
+void test_header_type()
+{
+    struct fixture *f = init(START_HEADER,
+            "# TYPE cmt_labels_test counter\n"
+            );
+    TEST_CHECK(parse(f) == 0);
+
+    TEST_CHECK(strcmp(f->context.metric.ns, "cmt") == 0);
+    TEST_CHECK(strcmp(f->context.metric.subsystem, "labels") == 0);
+    TEST_CHECK(strcmp(f->context.metric.name, "test") == 0);
+    TEST_CHECK(f->context.metric.type == COUNTER);
+    TEST_CHECK(f->context.metric.docstring == NULL);
+    cmt_sds_destroy(f->context.metric.name_orig);
+    free(f->context.metric.ns);
+
+    destroy(f);
+}
+
+void test_header_help_type()
+{
+    struct fixture *f = init(START_HEADER,
+            "# HELP cmt_labels_test Static labels test\n"
+            "# TYPE cmt_labels_test summary\n"
+            );
+
+    TEST_CHECK(parse(f) == 0);
+
+    TEST_CHECK(strcmp(f->context.metric.docstring, "Static labels test") == 0);
+    TEST_CHECK(strcmp(f->context.metric.ns, "cmt") == 0);
+    TEST_CHECK(strcmp(f->context.metric.subsystem, "labels") == 0);
+    TEST_CHECK(strcmp(f->context.metric.name, "test") == 0);
+    TEST_CHECK(f->context.metric.type == SUMMARY);
+    cmt_sds_destroy(f->context.metric.name_orig);
+    cmt_sds_destroy(f->context.metric.docstring);
+    free(f->context.metric.ns);
+
+    destroy(f);
+}
+
+void test_header_type_help()
+{
+    struct fixture *f = init(START_HEADER,
+            "# TYPE cmt_labels_test gauge\n"
+            "# HELP cmt_labels_test Static labels test\n"
+            );
+
+    TEST_CHECK(parse(f) == 0);
+
+    TEST_CHECK(strcmp(f->context.metric.docstring, "Static labels test") == 0);
+    TEST_CHECK(strcmp(f->context.metric.ns, "cmt") == 0);
+    TEST_CHECK(strcmp(f->context.metric.subsystem, "labels") == 0);
+    TEST_CHECK(strcmp(f->context.metric.name, "test") == 0);
+    TEST_CHECK(f->context.metric.type == GAUGE);
+    cmt_sds_destroy(f->context.metric.name_orig);
+    cmt_sds_destroy(f->context.metric.docstring);
+    free(f->context.metric.ns);
+
+    destroy(f);
+}
+
+void test_labels()
+{
+    struct fixture *f = init(START_LABELS, "dev=\"Calyptia\",lang=\"C\"");
+    TEST_CHECK(parse(f) == 0);
+    TEST_CHECK(f->context.metric.label_count == 2);
+    TEST_CHECK(strcmp(f->context.metric.labels[0], "dev") == 0);
+    TEST_CHECK(strcmp(f->context.metric.samples[0].label_values[0], "Calyptia") == 0);
+    TEST_CHECK(strcmp(f->context.metric.labels[1], "lang") == 0);
+    TEST_CHECK(strcmp(f->context.metric.samples[0].label_values[1], "C") == 0);
+    cmt_sds_destroy(f->context.metric.labels[0]);
+    cmt_sds_destroy(f->context.metric.samples[0].label_values[0]);
+    cmt_sds_destroy(f->context.metric.labels[1]);
+    cmt_sds_destroy(f->context.metric.samples[0].label_values[1]);
+    destroy(f);
+}
+
+void test_labels_trailing_comma()
+{
+    struct fixture *f = init(START_LABELS, "dev=\"Calyptia\",lang=\"C\",");
+    TEST_CHECK(parse(f) == 0);
+    TEST_CHECK(f->context.metric.label_count == 2);
+    TEST_CHECK(strcmp(f->context.metric.labels[0], "dev") == 0);
+    TEST_CHECK(strcmp(f->context.metric.samples[0].label_values[0], "Calyptia") == 0);
+    TEST_CHECK(strcmp(f->context.metric.labels[1], "lang") == 0);
+    TEST_CHECK(strcmp(f->context.metric.samples[0].label_values[1], "C") == 0);
+    cmt_sds_destroy(f->context.metric.labels[0]);
+    cmt_sds_destroy(f->context.metric.samples[0].label_values[0]);
+    cmt_sds_destroy(f->context.metric.labels[1]);
+    cmt_sds_destroy(f->context.metric.samples[0].label_values[1]);
+    destroy(f);
+}
+
+void test_sample()
+{
+    cmt_sds_t result;
+    const char expected[] = (
+            "# HELP cmt_labels_test some docstring\n"
+            "# TYPE cmt_labels_test counter\n"
+            "cmt_labels_test{dev=\"Calyptia\",lang=\"C\"} 1 0\n"
+            );
+
+    struct fixture *f = init(0,
+            "# HELP cmt_labels_test some docstring\n"
+            "# TYPE cmt_labels_test counter\n"
+            "cmt_labels_test{dev=\"Calyptia\",lang=\"C\",} 1 0\n"
+            );
+
+    TEST_CHECK(parse(f) == 0);
+    result = cmt_encode_prometheus_create(f->context.cmt, CMT_TRUE);
+    TEST_CHECK(strcmp(result, expected) == 0);
+    cmt_sds_destroy(result);
+
+    destroy(f);
+}
+
+void test_samples()
+{
+    cmt_sds_t result;
+    const char expected[] = (
+            "# HELP cmt_labels_test some docstring\n"
+            "# TYPE cmt_labels_test counter\n"
+            "cmt_labels_test{dev=\"Calyptia\",lang=\"C\"} 5 999999\n"
+            "cmt_labels_test{dev=\"Calyptia\",lang=\"C++\"} 6 7777\n"
+
+            );
+
+    struct fixture *f = init(0,
+            "# HELP cmt_labels_test some docstring\n"
+            "# TYPE cmt_labels_test counter\n"
+            "cmt_labels_test{dev=\"Calyptia\",lang=\"C\",} 5 999999\n"
+            "cmt_labels_test{dev=\"Calyptia\",lang=\"C++\"} 6 7777\n"
+            );
+
+    TEST_CHECK(parse(f) == 0);
+    result = cmt_encode_prometheus_create(f->context.cmt, CMT_TRUE);
+    TEST_CHECK(strcmp(result, expected) == 0);
+    cmt_sds_destroy(result);
+
+    destroy(f);
+}
+
+void test_escape_sequences()
+{
+    cmt_sds_t result;
+    // this "expected" value is not correct since the encoder doesn't handle
+    // escape sequences. I'm adding it here to verify that the parser is
+    // correctly treating escape sequences
+    const char expected[] = (
+        "# HELP msdos_file_access_time_seconds (no information)\n"
+        "# TYPE msdos_file_access_time_seconds untyped\n"
+        "msdos_file_access_time_seconds{path=\"C:\\DIR\\FILE.TXT\",error=\"Cannot find file:\n\"FILE.TXT\"\"} 1458255915 0\n"
+        );
+
+    struct fixture *f = init(0,
+        "# Escaping in label values:\n"
+        "msdos_file_access_time_seconds{path=\"C:\\\\DIR\\\\FILE.TXT\",error=\"Cannot find file:\\n\\\"FILE.TXT\\\"\"} 1.458255915e9\n"
+        );
+
+    TEST_CHECK(parse(f) == 0);
+    result = cmt_encode_prometheus_create(f->context.cmt, CMT_TRUE);
+    TEST_CHECK(strcmp(result, expected) == 0);
+    cmt_sds_destroy(result);
+
+    destroy(f);
+}
+
+void test_metric_without_labels()
+{ 
+    cmt_sds_t result;
+
+    const char expected[] =
+        "# HELP metric_without_timestamp_and_labels (no information)\n"
+        "# TYPE metric_without_timestamp_and_labels untyped\n"
+        "metric_without_timestamp_and_labels 12.470000000000001 0\n"
+        ;
+
+    struct fixture *f = init(0,
+        "# Minimalistic line:\n"
+        "metric_without_timestamp_and_labels 12.47\n"
+        );
+
+    TEST_CHECK(parse(f) == 0);
+    result = cmt_encode_prometheus_create(f->context.cmt, CMT_TRUE);
+    printf("\n%s\n", result);
+    TEST_CHECK(strcmp(result, expected) == 0);
+    cmt_sds_destroy(result);
+
+    destroy(f);
+}
+
+void test_complete()
+{
+    int status;
+    size_t offset;
+    cmt_sds_t result;
+    struct cmt *cmt;
+    const char in_buf[] =
+        "# TYPE http_requests_total counter\n"
+        "# HELP http_requests_total The total number of HTTP requests.\n"
+        "http_requests_total{method=\"post\",code=\"200\"} 1027 1395066363000\n"
+        "http_requests_total{method=\"post\",code=\"400\"}    3 1395066363000\n"
+        "\n"
+        "# Escaping in label values:\n"
+        "msdos_file_access_time_seconds{path=\"C:\\\\DIR\\\\FILE.TXT\",error=\"Cannot find file:\\n\\\"FILE.TXT\\\"\"} 1.458255915e9\n"
+        ;
+    const char expected[] =
+        "# HELP http_requests_total The total number of HTTP requests.\n"
+        "# TYPE http_requests_total counter\n"
+        "http_requests_total{method=\"post\",code=\"200\"} 1027 1395066363000\n"
+        "http_requests_total{method=\"post\",code=\"400\"} 3 1395066363000\n"
+        "# HELP msdos_file_access_time_seconds (no information)\n"
+        "# TYPE msdos_file_access_time_seconds untyped\n"
+        "msdos_file_access_time_seconds{path=\"C:\\DIR\\FILE.TXT\",error=\"Cannot find file:\n\"FILE.TXT\"\"} 1458255915 0\n"
+        ;
+
+    cmt_initialize();
+    status = cmt_decode_prometheus_create(&cmt, in_buf);
+    TEST_CHECK(status == 0);
+    result = cmt_encode_prometheus_create(cmt, CMT_TRUE);
+    TEST_CHECK(strcmp(result, expected) == 0);
+    printf("\n%s\n", result);
+    cmt_sds_destroy(result);
+    cmt_decode_prometheus_destroy(cmt);
+}
+
+
+TEST_LIST = {
+    {"header_help", test_header_help},
+    {"header_type", test_header_type},
+    {"header_help_type", test_header_help_type},
+    {"header_type_help", test_header_type_help},
+    {"labels", test_labels},
+    {"labels_trailing_comma", test_labels_trailing_comma},
+    {"sample", test_sample},
+    {"samples", test_samples},
+    {"escape_sequences", test_escape_sequences},
+    {"metric_without_labels", test_metric_without_labels},
+    {"complete", test_complete},
+    { 0 }
+};

--- a/tests/prometheus_parser.c
+++ b/tests/prometheus_parser.c
@@ -277,7 +277,6 @@ void test_metric_without_labels()
 
     TEST_CHECK(parse(f) == 0);
     result = cmt_encode_prometheus_create(f->context.cmt, CMT_TRUE);
-    printf("\n%s\n", result);
     TEST_CHECK(strcmp(result, expected) == 0);
     cmt_sds_destroy(result);
 
@@ -314,7 +313,6 @@ void test_complete()
     TEST_CHECK(status == 0);
     result = cmt_encode_prometheus_create(cmt, CMT_TRUE);
     TEST_CHECK(strcmp(result, expected) == 0);
-    printf("\n%s\n", result);
     cmt_sds_destroy(result);
     cmt_decode_prometheus_destroy(cmt);
 }

--- a/tests/prometheus_parser.c
+++ b/tests/prometheus_parser.c
@@ -412,6 +412,27 @@ void test_label_limits()
     TEST_CHECK(strcmp(errbuf, "maximum number of labels exceeded") == 0);
 }
 
+void test_invalid_types()
+{
+    int status;
+    char errbuf[256];
+    struct cmt *cmt;
+
+    status = cmt_decode_prometheus_create(&cmt,
+            "# HELP metric_name some docstring\n"
+            "# TYPE metric_name histogram\n"
+            "metric_name {key=\"abc\"} 32.4", errbuf, sizeof(errbuf));
+    TEST_CHECK(status == CMT_DECODE_PROMETHEUS_PARSE_UNSUPPORTED_TYPE);
+    TEST_CHECK(strcmp(errbuf, "unsupported metric type: histogram") == 0);
+
+    status = cmt_decode_prometheus_create(&cmt,
+            "# HELP metric_name some docstring\n"
+            "# TYPE metric_name summary\n"
+            "metric_name {key=\"abc\"} 32.4", errbuf, sizeof(errbuf));
+    TEST_CHECK(status == CMT_DECODE_PROMETHEUS_PARSE_UNSUPPORTED_TYPE);
+    TEST_CHECK(strcmp(errbuf, "unsupported metric type: summary") == 0);
+}
+
 TEST_LIST = {
     {"header_help", test_header_help},
     {"header_type", test_header_type},
@@ -426,5 +447,6 @@ TEST_LIST = {
     {"complete", test_complete},
     {"bison_parsing_error", test_bison_parsing_error},
     {"label_limits", test_label_limits},
+    {"invalid_types", test_invalid_types},
     { 0 }
 };

--- a/tests/prometheus_parser.c
+++ b/tests/prometheus_parser.c
@@ -285,7 +285,7 @@ void test_metric_without_labels()
     destroy(f);
 }
 
-void test_complete()
+void test_prometheus_spec_example()
 {
     char errbuf[256];
     int status;
@@ -359,7 +359,7 @@ void test_complete()
         "metric_without_timestamp_and_labels 12.470000000000001 0\n"
         "# HELP something_weird (no information)\n"
         "# TYPE something_weird untyped\n"
-        "something_weird{problem=\"division by zero\"} inf 3982045\n"
+        "something_weird{problem=\"division by zero\"} inf 0\n"
         "# HELP http_request_duration_seconds_sum (no information)\n"
         "# TYPE http_request_duration_seconds_sum untyped\n"
         "http_request_duration_seconds_sum 53423 0\n"
@@ -576,7 +576,7 @@ TEST_LIST = {
     {"samples", test_samples},
     {"escape_sequences", test_escape_sequences},
     {"metric_without_labels", test_metric_without_labels},
-    {"complete", test_complete},
+    {"prometheus_spec_example", test_prometheus_spec_example},
     {"bison_parsing_error", test_bison_parsing_error},
     {"label_limits", test_label_limits},
     {"invalid_types", test_invalid_types},

--- a/tests/prometheus_parser.c
+++ b/tests/prometheus_parser.c
@@ -321,63 +321,66 @@ void test_complete()
 
 void test_bison_parsing_error()
 {
+    // Note that in this test I commented checks for the error message. The
+    // reason is that the message is different depending on which bison
+    // version is used to generate the parser, so not fully deterministic.
     int status;
     char errbuf[256];
     struct cmt *cmt;
 
     status = cmt_decode_prometheus_create(&cmt, "", errbuf, sizeof(errbuf));
     TEST_CHECK(status == CMT_DECODE_PROMETHEUS_SYNTAX_ERROR);
-    TEST_CHECK(strcmp(errbuf,
-                "syntax error, unexpected end of file") == 0);
+    // TEST_CHECK(strcmp(errbuf,
+    //             "syntax error, unexpected end of file") == 0);
 
     status = cmt_decode_prometheus_create(&cmt,
             "# TYPE metric_name counter", errbuf, sizeof(errbuf));
     TEST_CHECK(status == CMT_DECODE_PROMETHEUS_SYNTAX_ERROR);
-    TEST_CHECK(strcmp(errbuf,
-                "syntax error, unexpected end of file, "
-                "expecting IDENTIFIER") == 0);
+    // TEST_CHECK(strcmp(errbuf,
+    //             "syntax error, unexpected end of file, "
+    //             "expecting IDENTIFIER") == 0);
 
     status = cmt_decode_prometheus_create(&cmt,
             "# HELP metric_name some docstring\n"
             "# TYPE metric_name counter\n"
             "metric_name", errbuf, sizeof(errbuf));
     TEST_CHECK(status == CMT_DECODE_PROMETHEUS_SYNTAX_ERROR);
-    TEST_CHECK(strcmp(errbuf,
-                "syntax error, unexpected end of file, expecting '{' "
-                "or FPOINT or INTEGER") == 0);
+    // TEST_CHECK(strcmp(errbuf,
+    //             "syntax error, unexpected end of file, expecting '{' "
+    //             "or FPOINT or INTEGER") == 0);
 
     status = cmt_decode_prometheus_create(&cmt,
             "# HELP metric_name some docstring\n"
             "# TYPE metric_name counter\n"
             "metric_name {key", errbuf, sizeof(errbuf));
     TEST_CHECK(status == CMT_DECODE_PROMETHEUS_SYNTAX_ERROR);
-    TEST_CHECK(strcmp(errbuf,
-                "syntax error, unexpected end of file, expecting '='") == 0);
+    // TEST_CHECK(strcmp(errbuf,
+    //             "syntax error, unexpected end of file, expecting '='") == 0);
 
     status = cmt_decode_prometheus_create(&cmt,
             "# HELP metric_name some docstring\n"
             "# TYPE metric_name counter\n"
             "metric_name {key=", errbuf, sizeof(errbuf));
     TEST_CHECK(status == CMT_DECODE_PROMETHEUS_SYNTAX_ERROR);
-    TEST_CHECK(strcmp(errbuf,
-                "syntax error, unexpected end of file, expecting QUOTED") == 0);
+    // TEST_CHECK(strcmp(errbuf,
+    //             "syntax error, unexpected end of file, expecting QUOTED") == 0);
 
     status = cmt_decode_prometheus_create(&cmt,
             "# HELP metric_name some docstring\n"
             "# TYPE metric_name counter\n"
             "metric_name {key=\"abc\"", errbuf, sizeof(errbuf));
     TEST_CHECK(status == CMT_DECODE_PROMETHEUS_SYNTAX_ERROR);
-    TEST_CHECK(strcmp(errbuf,
-                "syntax error, unexpected end of file, expecting '}'") == 0);
+    // TEST_CHECK(strcmp(errbuf,
+    //             "syntax error, unexpected end of file, expecting '}'") == 0);
 
     status = cmt_decode_prometheus_create(&cmt,
             "# HELP metric_name some docstring\n"
             "# TYPE metric_name counter\n"
             "metric_name {key=\"abc\"}", errbuf, sizeof(errbuf));
     TEST_CHECK(status == CMT_DECODE_PROMETHEUS_SYNTAX_ERROR);
-    TEST_CHECK(strcmp(errbuf,
-                "syntax error, unexpected end of file, expecting "
-                "FPOINT or INTEGER") == 0);
+    // TEST_CHECK(strcmp(errbuf,
+    //             "syntax error, unexpected end of file, expecting "
+    //             "FPOINT or INTEGER") == 0);
 }
 
 void test_label_limits()

--- a/tests/prometheus_parser.c
+++ b/tests/prometheus_parser.c
@@ -436,6 +436,36 @@ void test_invalid_types()
     TEST_CHECK(strcmp(errbuf, "unsupported metric type: summary") == 0);
 }
 
+void test_invalid_value()
+{
+    int status;
+    char errbuf[256];
+    struct cmt *cmt;
+
+    status = cmt_decode_prometheus_create(&cmt,
+            "# HELP metric_name some docstring\n"
+            "# TYPE metric_name histogram\n"
+            "metric_name {key=\"abc\"} 10e", errbuf, sizeof(errbuf));
+    TEST_CHECK(status == CMT_DECODE_PROMETHEUS_PARSE_VALUE_FAILED);
+    TEST_CHECK(strcmp(errbuf,
+                "failed to parse sample: \"10e\" is not a valid value") == 0);
+}
+
+void test_invalid_timestamp()
+{
+    int status;
+    char errbuf[256];
+    struct cmt *cmt;
+
+    status = cmt_decode_prometheus_create(&cmt,
+            "# HELP metric_name some docstring\n"
+            "# TYPE metric_name histogram\n"
+            "metric_name {key=\"abc\"} 10 3e", errbuf, sizeof(errbuf));
+    TEST_CHECK(status == CMT_DECODE_PROMETHEUS_PARSE_TIMESTAMP_FAILED);
+    TEST_CHECK(strcmp(errbuf,
+                "failed to parse sample: \"3e\" is not a valid timestamp") == 0);
+}
+
 TEST_LIST = {
     {"header_help", test_header_help},
     {"header_type", test_header_type},
@@ -451,5 +481,7 @@ TEST_LIST = {
     {"bison_parsing_error", test_bison_parsing_error},
     {"label_limits", test_label_limits},
     {"invalid_types", test_invalid_types},
+    {"invalid_value", test_invalid_value},
+    {"invalid_timestamp", test_invalid_timestamp},
     { 0 }
 };


### PR DESCRIPTION
Opening the PR for anyone that wants to start reviewing the overall design, but still WIP. Here's what is still missing:

- [x] Proper float parsing, we need to handle everything supported by golang's [ParseFloat](https://pkg.go.dev/strconv#ParseFloat)
- [x] Allocation failure checks
- [x] Proper parsing error handling (right now it prints the error to stderr)
- [x] More testing. Ideally I want to cover the entire example shown on the [exposition format spec](https://github.com/prometheus/docs/blob/main/content/docs/instrumenting/exposition_formats.md)