### PR TITLE
Allow passing a default timestamp to prometheus decode API

### DIFF
--- a/include/cmetrics/cmt_decode_prometheus.h
+++ b/include/cmetrics/cmt_decode_prometheus.h
@@ -20,6 +20,8 @@
 #ifndef CMT_DECODE_PROMETHEUS_H
 #define CMT_DECODE_PROMETHEUS_H
 
+#include <stdbool.h>
+
 #include "monkey/mk_core/mk_list.h"
 #include <cmetrics/cmetrics.h>
 
@@ -70,6 +72,7 @@ struct cmt_decode_prometheus_parse_opts {
     uint64_t default_timestamp;
     char *errbuf;
     size_t errbuf_size;
+    bool skip_unsupported_type;
 };
 
 struct cmt_decode_prometheus_context {

--- a/include/cmetrics/cmt_decode_prometheus.h
+++ b/include/cmetrics/cmt_decode_prometheus.h
@@ -92,8 +92,11 @@ int cmt_decode_prometheus_lex(YYSTYPE *yylval_param,
 #include "cmt_decode_prometheus_lexer.h"
 #endif
 
-int cmt_decode_prometheus_create(struct cmt **out_cmt, const char *in_buf,
-         struct cmt_decode_prometheus_parse_opts *opts);
+int cmt_decode_prometheus_create(
+        struct cmt **out_cmt,
+        const char *in_buf,
+        size_t in_size,
+        struct cmt_decode_prometheus_parse_opts *opts);
 void cmt_decode_prometheus_destroy(struct cmt *cmt);
 
 #endif

--- a/include/cmetrics/cmt_decode_prometheus.h
+++ b/include/cmetrics/cmt_decode_prometheus.h
@@ -46,7 +46,7 @@
 
 struct cmt_decode_prometheus_context_sample {
     double value;
-    int64_t timestamp;
+    uint64_t timestamp;
     size_t label_count;
     cmt_sds_t label_values[CMT_DECODE_PROMETHEUS_MAX_LABEL_COUNT];
 
@@ -67,6 +67,7 @@ struct cmt_decode_prometheus_context_metric {
 
 struct cmt_decode_prometheus_parse_opts {
     int start_token;
+    uint64_t default_timestamp;
     char *errbuf;
     size_t errbuf_size;
 };

--- a/include/cmetrics/cmt_decode_prometheus.h
+++ b/include/cmetrics/cmt_decode_prometheus.h
@@ -65,12 +65,16 @@ struct cmt_decode_prometheus_context_metric {
     struct mk_list samples;
 };
 
-struct cmt_decode_prometheus_context {
-    struct cmt *cmt;
-    int errcode;
+struct cmt_decode_prometheus_parse_opts {
+    int start_token;
     char *errbuf;
     size_t errbuf_size;
-    int start_token;
+};
+
+struct cmt_decode_prometheus_context {
+    struct cmt *cmt;
+    struct cmt_decode_prometheus_parse_opts opts;
+    int errcode;
     cmt_sds_t strbuf;
     struct cmt_decode_prometheus_context_metric metric;
 };
@@ -88,7 +92,7 @@ int cmt_decode_prometheus_lex(YYSTYPE *yylval_param,
 #endif
 
 int cmt_decode_prometheus_create(struct cmt **out_cmt, const char *in_buf,
-         char *errbuf, size_t errbuf_size);
+         struct cmt_decode_prometheus_parse_opts *opts);
 void cmt_decode_prometheus_destroy(struct cmt *cmt);
 
 #endif

--- a/src/cmt_decode_prometheus.c
+++ b/src/cmt_decode_prometheus.c
@@ -77,8 +77,12 @@ static void reset_context(struct cmt_decode_prometheus_context *context)
     mk_list_init(&context->metric.samples);
 }
 
-int cmt_decode_prometheus_create(struct cmt **out_cmt, const char *in_buf,
-         struct cmt_decode_prometheus_parse_opts *opts)
+
+int cmt_decode_prometheus_create(
+        struct cmt **out_cmt,
+        const char *in_buf,
+        size_t in_size,
+        struct cmt_decode_prometheus_parse_opts *opts)
 {
     yyscan_t scanner;
     YY_BUFFER_STATE buf;
@@ -99,7 +103,10 @@ int cmt_decode_prometheus_create(struct cmt **out_cmt, const char *in_buf,
     }
     mk_list_init(&(context.metric.samples));
     cmt_decode_prometheus_lex_init(&scanner);
-    buf = cmt_decode_prometheus__scan_string(in_buf, scanner);
+    if (!in_size) {
+        in_size = strlen(in_buf);
+    }
+    buf = cmt_decode_prometheus__scan_bytes((char *)in_buf, in_size, scanner);
     if (!buf) {
         cmt_destroy(cmt);
         return CMT_DECODE_PROMETHEUS_ALLOCATION_ERROR;

--- a/src/cmt_decode_prometheus.c
+++ b/src/cmt_decode_prometheus.c
@@ -428,10 +428,18 @@ static int sample_start(struct cmt_decode_prometheus_context *context)
     return 0;
 }
 
-static int parse_timestamp(const char *in, int64_t *out)
+static int parse_timestamp(
+        struct cmt_decode_prometheus_context *context,
+        const char *in, uint64_t *out)
 {
     char *end;
     int64_t val;
+
+    if (!strlen(in)) {
+        // No timestamp was specified, use default value
+        *out = context->opts.default_timestamp;
+        return 0;
+    }
 
     errno = 0;
     val = strtol(in, &end, 10);
@@ -480,7 +488,7 @@ static int parse_sample(
                 "value", value);
     }
 
-    if (parse_timestamp(timestamp, &sample->timestamp)) {
+    if (parse_timestamp(context, timestamp, &sample->timestamp)) {
         return report_error(context,
                 CMT_DECODE_PROMETHEUS_PARSE_TIMESTAMP_FAILED,
                 "failed to parse sample: \"%s\" is not a valid "

--- a/src/cmt_decode_prometheus.c
+++ b/src/cmt_decode_prometheus.c
@@ -325,10 +325,14 @@ static int finish_metric(struct cmt_decode_prometheus_context *context)
             break;
         case HISTOGRAM:
         case SUMMARY:
-            rv = report_error(context,
-                    CMT_DECODE_PROMETHEUS_PARSE_UNSUPPORTED_TYPE,
-                    "unsupported metric type: %s",
-                    context->metric.type == HISTOGRAM ? "histogram" : "summary");
+            if (context->opts.skip_unsupported_type) {
+                rv = 0;
+            } else {
+                rv = report_error(context,
+                        CMT_DECODE_PROMETHEUS_PARSE_UNSUPPORTED_TYPE,
+                        "unsupported metric type: %s",
+                        context->metric.type == HISTOGRAM ? "histogram" : "summary");
+            }
             break;
         default:
             rv = add_metric_untyped(context);

--- a/src/cmt_decode_prometheus.c
+++ b/src/cmt_decode_prometheus.c
@@ -78,7 +78,7 @@ static void reset_context(struct cmt_decode_prometheus_context *context)
 }
 
 int cmt_decode_prometheus_create(struct cmt **out_cmt, const char *in_buf,
-        char *errbuf, size_t errbuf_size)
+         struct cmt_decode_prometheus_parse_opts *opts)
 {
     yyscan_t scanner;
     YY_BUFFER_STATE buf;
@@ -94,8 +94,9 @@ int cmt_decode_prometheus_create(struct cmt **out_cmt, const char *in_buf,
 
     memset(&context, 0, sizeof(context));
     context.cmt = cmt;
-    context.errbuf = errbuf;
-    context.errbuf_size = errbuf_size;
+    if (opts) {
+        context.opts = *opts;
+    }
     mk_list_init(&(context.metric.samples));
     cmt_decode_prometheus_lex_init(&scanner);
     buf = cmt_decode_prometheus__scan_string(in_buf, scanner);
@@ -135,8 +136,8 @@ static int report_error(struct cmt_decode_prometheus_context *context,
     va_list args;
     va_start(args, format);
     context->errcode = errcode;
-    if (context->errbuf && context->errbuf_size) {
-        vsnprintf(context->errbuf, context->errbuf_size - 1, format, args);
+    if (context->opts.errbuf && context->opts.errbuf_size) {
+        vsnprintf(context->opts.errbuf, context->opts.errbuf_size - 1, format, args);
     }
     va_end(args);
     return errcode;
@@ -449,7 +450,7 @@ static int parse_timestamp(const char *in, int64_t *out)
     return 0;
 }
 
-static int parse_value(char *in, double *out)
+static int parse_value(const char *in, double *out)
 {
     char *end;
     double val;

--- a/src/cmt_decode_prometheus.l
+++ b/src/cmt_decode_prometheus.l
@@ -22,9 +22,9 @@
 %%
 
 %{
-    if (context->start_token) {
-        int t = context->start_token;
-        context->start_token = 0;
+    if (context->opts.start_token) {
+        int t = context->opts.start_token;
+        context->opts.start_token = 0;
         return t;
     }
 %}

--- a/src/cmt_decode_prometheus.y
+++ b/src/cmt_decode_prometheus.y
@@ -132,7 +132,7 @@ values:
         }
     }
   | value {
-        if (parse_sample(context, $1, "0")) {
+        if (parse_sample(context, $1, "")) {
             YYABORT;
         }
     }

--- a/tests/prometheus_parser.c
+++ b/tests/prometheus_parser.c
@@ -555,6 +555,31 @@ void test_invalid_timestamp()
                 "failed to parse sample: \"3e\" is not a valid timestamp") == 0);
 }
 
+void test_default_timestamp()
+{
+    int status;
+    cmt_sds_t result;
+    struct cmt *cmt;
+    struct cmt_decode_prometheus_parse_opts opts = {
+        .errbuf_size = 0,
+        .errbuf = NULL,
+        .default_timestamp = 557 * 10e5
+    };
+
+    status = cmt_decode_prometheus_create(&cmt,
+            "# HELP metric_name some docstring\n"
+            "# TYPE metric_name counter\n"
+            "metric_name {key=\"abc\"} 10", &opts);
+    TEST_CHECK(status == 0);
+    result = cmt_encode_prometheus_create(cmt, CMT_TRUE);
+    TEST_CHECK(strcmp(result,
+            "# HELP metric_name some docstring\n"
+            "# TYPE metric_name counter\n"
+            "metric_name{key=\"abc\"} 10 557\n") == 0);
+    cmt_sds_destroy(result);
+    cmt_decode_prometheus_destroy(cmt);
+}
+
 void test_values()
 {
     int status;
@@ -606,6 +631,7 @@ TEST_LIST = {
     {"invalid_types", test_invalid_types},
     {"invalid_value", test_invalid_value},
     {"invalid_timestamp", test_invalid_timestamp},
+    {"default_timestamp", test_default_timestamp},
     {"values", test_values},
     { 0 }
 };


### PR DESCRIPTION
- Modify prometheus decode API to receive opts struct which encapsulates errbuf/errbuf_size
- Add default_timestamp option

@edsiper the reason I added a default_timestamp option (instead of calling `cmt_time_now()` directly when parsing) is that it is more flexible and allows easier testing. I've added a test example, but you can use current scrape timestamp like this:

```C
const char *inbuf = ...;
struct cmt *cmt;
struct cmt_decode_prometheus_parse_opts opts = {
    .errbuf = NULL,
    .default_timestamp = cmt_time_now()
};
cmt_decode_prometheus_create(&cmt, inbuf, &opts);
```

This API change will also make it easier customize parsing in the future without breaking existing callers.

fix #67 