### PR TITLE
workflows: centos7 build

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -6,7 +6,7 @@ on:
   pull_request:
     branches:
       - master
-    types: [opened, edited, synchronize]
+    types: [opened, reopened, synchronize]
 jobs:
   build-windows:
     name: Build sources on amd64 for ${{ matrix.os }}
@@ -24,6 +24,31 @@ jobs:
       - name: Run unit tests.
         run: |
           ctest --rerun-failed --output-on-failure -C Debug --test-dir .\tests\
+
+  build-centos:
+    name: CentOS 7 build to confirm no issues once used downstream
+    runs-on: ubuntu-latest
+    container: centos:7
+    steps:
+      - name: Set up base image dependencies
+        run: |
+          yum -y update && \
+          yum install -y rpm-build curl ca-certificates gcc gcc-c++ cmake make bash \
+                        wget unzip systemd-devel wget flex bison \
+                        cyrus-sasl-lib cyrus-sasl-devel openssl openss-libs openssl-devel \
+                        postgresql-libs postgresql-devel postgresql-server postgresql && \
+          wget http://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm && \
+          rpm -ivh epel-release-latest-7.noarch.rpm && \
+          yum install -y cmake3
+
+      - uses: actions/checkout@v2
+
+      - name: Run compilation
+        run: |
+          cd build
+          cmake3 -DCMT_TESTS=on -DCMT_DEV=on ../
+          make
+
   build-unix:
     name: Build sources on amd64 for ${{ matrix.os }} - ${{ matrix.compiler }}
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -45,8 +45,7 @@ jobs:
 
       - name: Run compilation
         run: |
-          cd build
-          cmake3 -DCMT_TESTS=on -DCMT_DEV=on ../
+          cmake3 -DCMT_TESTS=on -DCMT_DEV=on .
           make
 
   build-unix:


### PR DESCRIPTION
Resolves #75 by adding build check for CentOS 7.
Note that this fails the actual check because of #74.
We only do a quick build during CI, we are not detaining any packages built.