### PR TITLE
Plug an implicit function warning for lex

### DIFF
--- a/include/cmetrics/cmt_decode_prometheus.h
+++ b/include/cmetrics/cmt_decode_prometheus.h
@@ -74,10 +74,12 @@ struct cmt_decode_prometheus_context {
     struct cmt_decode_prometheus_context_metric metric;
 };
 
-#define YY_DECL int cmt_decode_prometheus_lex \
+#define LEX_DECL int cmt_decode_prometheus_lex \
                (YYSTYPE * yylval_param, \
                void* yyscanner, \
                struct cmt_decode_prometheus_context *context)
+
+#define YY_DECL LEX_DECL
 
 #include "cmt_decode_prometheus_parser.h"
 
@@ -86,6 +88,8 @@ struct cmt_decode_prometheus_context {
 // which defines FLEX_SCANNER
 #include "cmt_decode_prometheus_lexer.h"
 #endif
+
+LEX_DECL; /* Declear as an entity of yylex function declaration. */
 
 int cmt_decode_prometheus_create(
         struct cmt **out_cmt,


### PR DESCRIPTION
macOS's toolchain should be failed with implicit declaration of yylex entity function.
We should declare it explicitly for preventing implicit declaration error.

Fixes #78.

Signed-off-by: Hiroshi Hatake <hatake@calyptia.com>