### PR TITLE
encode: prometheus: Handle escaping of special characters

### DIFF
--- a/tests/encoding.c
+++ b/tests/encoding.c
@@ -523,28 +523,31 @@ void test_prometheus()
     struct cmt *cmt;
     struct cmt_counter *c;
 
-    char *out1 = "# HELP cmt_labels_test Static labels test\n"
+    char *out1 = "# HELP cmt_labels_test \"Static\\\\ labels \\ntest\n"
                  "# TYPE cmt_labels_test counter\n"
                  "cmt_labels_test 1 0\n"
-                 "cmt_labels_test{host=\"calyptia.com\",app=\"cmetrics\"} 2 0\n";
+                 "cmt_labels_test{host=\"calyptia.com\",app=\"cmetrics\"} 2 0\n"
+                 "cmt_labels_test{host=\"\\\"calyptia.com\\\"\",app=\"cme\\\\tr\\nics\"} 1 0\n";
 
-    char *out2 = "# HELP cmt_labels_test Static labels test\n"
+    char *out2 = "# HELP cmt_labels_test \"Static\\\\ labels \\ntest\n"
         "# TYPE cmt_labels_test counter\n"
-        "cmt_labels_test{dev=\"Calyptia\",lang=\"C\"} 1 0\n"
-        "cmt_labels_test{dev=\"Calyptia\",lang=\"C\",host=\"calyptia.com\",app=\"cmetrics\"} 2 0\n";
+        "cmt_labels_test{dev=\"Calyptia\",lang=\"C\\\"\\\\\\n\"} 1 0\n"
+        "cmt_labels_test{dev=\"Calyptia\",lang=\"C\\\"\\\\\\n\",host=\"calyptia.com\",app=\"cmetrics\"} 2 0\n"
+        "cmt_labels_test{dev=\"Calyptia\",lang=\"C\\\"\\\\\\n\",host=\"\\\"calyptia.com\\\"\",app=\"cme\\\\tr\\nics\"} 1 0\n";
 
     cmt_initialize();
 
     cmt = cmt_create();
     TEST_CHECK(cmt != NULL);
 
-    c = cmt_counter_create(cmt, "cmt", "labels", "test", "Static labels test",
+    c = cmt_counter_create(cmt, "cmt", "labels", "test", "\"Static\\ labels \ntest",
                            2, (char *[]) {"host", "app"});
 
     ts = 0;
     cmt_counter_inc(c, ts, 0, NULL);
     cmt_counter_inc(c, ts, 2, (char *[]) {"calyptia.com", "cmetrics"});
     cmt_counter_inc(c, ts, 2, (char *[]) {"calyptia.com", "cmetrics"});
+    cmt_counter_inc(c, ts, 2, (char *[]) {"\"calyptia.com\"", "cme\\tr\nics"});
 
     /* Encode to prometheus (no static labels) */
     text = cmt_encode_prometheus_create(cmt, CMT_TRUE);
@@ -554,7 +557,7 @@ void test_prometheus()
 
     /* append static labels */
     cmt_label_add(cmt, "dev", "Calyptia");
-    cmt_label_add(cmt, "lang", "C");
+    cmt_label_add(cmt, "lang", "C\"\\\n");
 
     text = cmt_encode_prometheus_create(cmt, CMT_TRUE);
     printf("%s\n", text);
@@ -663,15 +666,15 @@ void test_influx()
 }
 
 TEST_LIST = {
-    // {"cmt_msgpack_partial_processing", test_cmt_msgpack_partial_processing},
-    // {"prometheus_remote_write",        test_prometheus_remote_write},
-    // {"cmt_msgpack_stability",          test_cmt_to_msgpack_stability},
-    // {"cmt_msgpack_integrity",          test_cmt_to_msgpack_integrity},
-    // {"cmt_msgpack_labels",             test_cmt_to_msgpack_labels},
-    // {"cmt_msgpack",                    test_cmt_to_msgpack},
+    {"cmt_msgpack_partial_processing", test_cmt_msgpack_partial_processing},
+    {"prometheus_remote_write",        test_prometheus_remote_write},
+    {"cmt_msgpack_stability",          test_cmt_to_msgpack_stability},
+    {"cmt_msgpack_integrity",          test_cmt_to_msgpack_integrity},
+    {"cmt_msgpack_labels",             test_cmt_to_msgpack_labels},
+    {"cmt_msgpack",                    test_cmt_to_msgpack},
     {"opentelemetry",                  test_opentelemetry},
-    // {"prometheus",                     test_prometheus},
-    // {"text",                           test_text},
-    // {"influx",                         test_influx},
+    {"prometheus",                     test_prometheus},
+    {"text",                           test_text},
+    {"influx",                         test_influx},
     { 0 }
 };

--- a/tests/prometheus_parser.c
+++ b/tests/prometheus_parser.c
@@ -241,13 +241,10 @@ void test_samples()
 void test_escape_sequences()
 {
     cmt_sds_t result;
-    // this "expected" value is not correct since the encoder doesn't handle
-    // escape sequences. I'm adding it here to verify that the parser is
-    // correctly treating escape sequences
     const char expected[] = (
         "# HELP msdos_file_access_time_seconds (no information)\n"
         "# TYPE msdos_file_access_time_seconds untyped\n"
-        "msdos_file_access_time_seconds{path=\"C:\\DIR\\FILE.TXT\",error=\"Cannot find file:\n\"FILE.TXT\"\"} 1458255915 0\n"
+        "msdos_file_access_time_seconds{path=\"C:\\\\DIR\\\\FILE.TXT\",error=\"Cannot find file:\\n\\\"FILE.TXT\\\"\"} 1458255915 0\n"
         );
 
     struct fixture *f = init(0,
@@ -357,8 +354,7 @@ void test_prometheus_spec_example()
         "rpc_duration_seconds{quantile=\"0.99\"} 76656 0\n"
         "# HELP msdos_file_access_time_seconds (no information)\n"
         "# TYPE msdos_file_access_time_seconds untyped\n"
-        // notice how scientific notation cannot be parsed by strtod
-        "msdos_file_access_time_seconds{path=\"C:\\DIR\\FILE.TXT\",error=\"Cannot find file:\n\"FILE.TXT\"\"} 1458255915 0\n"
+        "msdos_file_access_time_seconds{path=\"C:\\\\DIR\\\\FILE.TXT\",error=\"Cannot find file:\\n\\\"FILE.TXT\\\"\"} 1458255915 0\n"
         "# HELP metric_without_timestamp_and_labels (no information)\n"
         "# TYPE metric_without_timestamp_and_labels untyped\n"
         "metric_without_timestamp_and_labels 12.470000000000001 0\n"
@@ -373,7 +369,6 @@ void test_prometheus_spec_example()
         "http_request_duration_seconds_count 144320 0\n"
         "# HELP rpc_duration_seconds_sum (no information)\n"
         "# TYPE rpc_duration_seconds_sum untyped\n"
-        // notice how scientific notation cannot be parsed by strtod
         "rpc_duration_seconds_sum 17560473 0\n"
         "# HELP rpc_duration_seconds_count (no information)\n"
         "# TYPE rpc_duration_seconds_count untyped\n"
@@ -630,8 +625,8 @@ void test_values()
             "metric_name{key=\"simple float\"} 12.470000000000001 0\n"
             "metric_name{key=\"scientific notation 1\"} 17560473 0\n"
             "metric_name{key=\"scientific notation 2\"} 1.7560473000000001 0\n"
-            "metric_name{key=\"Positive \"not a number\"\"} nan 0\n"
-            "metric_name{key=\"Negative \"not a number\"\"} -nan 0\n"
+            "metric_name{key=\"Positive \\\"not a number\\\"\"} nan 0\n"
+            "metric_name{key=\"Negative \\\"not a number\\\"\"} -nan 0\n"
             "metric_name{key=\"Positive infinity\"} inf 0\n"
             "metric_name{key=\"Negative infinity\"} -inf 0\n") == 0);
     cmt_sds_destroy(result);


### PR DESCRIPTION
Fix prometheus encoder to escape special characters in HELP description and label values.