### PR TITLE
Allow empty metric help

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 build/*
 include/cmetrics/cmt_info.h
 include/cmetrics/cmt_version.h
+payload.bin

--- a/src/cmt_counter.c
+++ b/src/cmt_counter.c
@@ -46,11 +46,6 @@ struct cmt_counter *cmt_counter_create(struct cmt *cmt,
         return NULL;
     }
 
-    if (!help || strlen(help) == 0) {
-        cmt_log_error(cmt, "undefined help");
-        return NULL;
-    }
-
     counter = calloc(1, sizeof(struct cmt_counter));
     if (!counter) {
         cmt_errno();

--- a/src/cmt_decode_prometheus.c
+++ b/src/cmt_decode_prometheus.c
@@ -182,14 +182,6 @@ static int split_metric_name(struct cmt_decode_prometheus_context *context,
     return 0;
 }
 
-// Use this helper function to return a stub value for docstring when it is not
-// available. This is necessary for now because the metric constructors require
-// a docstring, even though it is not required by prometheus spec.
-static const char *get_docstring(struct cmt_decode_prometheus_context *context)
-{
-    return context->metric.docstring ? context->metric.docstring : "(no information)";
-}
-
 static int add_metric_counter(struct cmt_decode_prometheus_context *context)
 {
     int i;
@@ -203,7 +195,7 @@ static int add_metric_counter(struct cmt_decode_prometheus_context *context)
             context->metric.ns,
             context->metric.subsystem,
             context->metric.name,
-            get_docstring(context),
+            context->metric.docstring,
             context->metric.label_count,
             context->metric.labels);
 
@@ -243,7 +235,7 @@ static int add_metric_gauge(struct cmt_decode_prometheus_context *context)
             context->metric.ns,
             context->metric.subsystem,
             context->metric.name,
-            get_docstring(context),
+            context->metric.docstring,
             context->metric.label_count,
             context->metric.labels);
 
@@ -283,7 +275,7 @@ static int add_metric_untyped(struct cmt_decode_prometheus_context *context)
             context->metric.ns,
             context->metric.subsystem,
             context->metric.name,
-            get_docstring(context),
+            context->metric.docstring,
             context->metric.label_count,
             context->metric.labels);
 

--- a/src/cmt_encode_msgpack.c
+++ b/src/cmt_encode_msgpack.c
@@ -203,7 +203,11 @@ static void pack_header(mpack_writer_t *writer, struct cmt *cmt, struct cmt_map 
 
     /* opts['description'] */
     mpack_write_cstr(writer, "desc");
-    mpack_write_cstr(writer, opts->description);
+    if (opts->description) {
+        mpack_write_cstr(writer, opts->description);
+    } else {
+        mpack_write_nil(writer);
+    }
 
     mpack_finish_map(writer); /* 'opts' */
 

--- a/src/cmt_encode_prometheus.c
+++ b/src/cmt_encode_prometheus.c
@@ -69,13 +69,15 @@ static void metric_banner(cmt_sds_t *buf, struct cmt_map *map,
 
     opts = map->opts;
 
-    /* HELP */
-    cmt_sds_cat_safe(buf, "# HELP ", 7);
-    cmt_sds_cat_safe(buf, opts->fqname, cmt_sds_len(opts->fqname));
+    if (opts->description) {
+        /* HELP */
+        cmt_sds_cat_safe(buf, "# HELP ", 7);
+        cmt_sds_cat_safe(buf, opts->fqname, cmt_sds_len(opts->fqname));
 
-    cmt_sds_cat_safe(buf, " ", 1);
-    metric_escape(buf, opts->description, false);
-    cmt_sds_cat_safe(buf, "\n", 1);
+        cmt_sds_cat_safe(buf, " ", 1);
+        metric_escape(buf, opts->description, false);
+        cmt_sds_cat_safe(buf, "\n", 1);
+    }
 
     /* TYPE */
     cmt_sds_cat_safe(buf, "# TYPE ", 7);

--- a/src/cmt_gauge.c
+++ b/src/cmt_gauge.c
@@ -46,11 +46,6 @@ struct cmt_gauge *cmt_gauge_create(struct cmt *cmt,
         return NULL;
     }
 
-    if (!help || strlen(help) == 0) {
-        cmt_log_error(cmt, "undefined help");
-        return NULL;
-    }
-
     gauge = calloc(1, sizeof(struct cmt_gauge));
     if (!gauge) {
         cmt_errno();

--- a/src/cmt_opts.c
+++ b/src/cmt_opts.c
@@ -74,9 +74,14 @@ int cmt_opts_init(struct cmt_opts *opts,
     }
 
     opts->name = cmt_sds_create(name);
-    opts->description = cmt_sds_create(description);
 
-    if (!opts->name || !opts->description) {
+    if (description) {
+        opts->description = cmt_sds_create(description);
+    } else {
+        opts->description = NULL;
+    }
+
+    if (!opts->name) {
         return -1;
     }
 

--- a/src/cmt_untyped.c
+++ b/src/cmt_untyped.c
@@ -41,18 +41,8 @@ struct cmt_untyped *cmt_untyped_create(struct cmt *cmt,
         return NULL;
     }
 
-    if (!help || strlen(help) == 0) {
-        cmt_log_error(cmt, "undefined help");
-        return NULL;
-    }
-
     if (!name || strlen(name) == 0) {
         cmt_log_error(cmt, "undefined name");
-        return NULL;
-    }
-
-    if (!help || strlen(help) == 0) {
-        cmt_log_error(cmt, "undefined help");
         return NULL;
     }
 

--- a/tests/prometheus_parser.c
+++ b/tests/prometheus_parser.c
@@ -242,7 +242,6 @@ void test_escape_sequences()
 {
     cmt_sds_t result;
     const char expected[] = (
-        "# HELP msdos_file_access_time_seconds (no information)\n"
         "# TYPE msdos_file_access_time_seconds untyped\n"
         "msdos_file_access_time_seconds{path=\"C:\\\\DIR\\\\FILE.TXT\",error=\"Cannot find file:\\n\\\"FILE.TXT\\\"\"} 1458255915 0\n"
         );
@@ -265,7 +264,6 @@ void test_metric_without_labels()
     cmt_sds_t result;
 
     const char expected[] =
-        "# HELP metric_without_timestamp_and_labels (no information)\n"
         "# TYPE metric_without_timestamp_and_labels untyped\n"
         "metric_without_timestamp_and_labels 12.470000000000001 0\n"
         ;
@@ -352,25 +350,18 @@ void test_prometheus_spec_example()
         "rpc_duration_seconds{quantile=\"0.5\"} 4773 0\n"
         "rpc_duration_seconds{quantile=\"0.9\"} 9001 0\n"
         "rpc_duration_seconds{quantile=\"0.99\"} 76656 0\n"
-        "# HELP msdos_file_access_time_seconds (no information)\n"
         "# TYPE msdos_file_access_time_seconds untyped\n"
         "msdos_file_access_time_seconds{path=\"C:\\\\DIR\\\\FILE.TXT\",error=\"Cannot find file:\\n\\\"FILE.TXT\\\"\"} 1458255915 0\n"
-        "# HELP metric_without_timestamp_and_labels (no information)\n"
         "# TYPE metric_without_timestamp_and_labels untyped\n"
         "metric_without_timestamp_and_labels 12.470000000000001 0\n"
-        "# HELP something_weird (no information)\n"
         "# TYPE something_weird untyped\n"
         "something_weird{problem=\"division by zero\"} inf 0\n"
-        "# HELP http_request_duration_seconds_sum (no information)\n"
         "# TYPE http_request_duration_seconds_sum untyped\n"
         "http_request_duration_seconds_sum 53423 0\n"
-        "# HELP http_request_duration_seconds_count (no information)\n"
         "# TYPE http_request_duration_seconds_count untyped\n"
         "http_request_duration_seconds_count 144320 0\n"
-        "# HELP rpc_duration_seconds_sum (no information)\n"
         "# TYPE rpc_duration_seconds_sum untyped\n"
         "rpc_duration_seconds_sum 17560473 0\n"
-        "# HELP rpc_duration_seconds_count (no information)\n"
         "# TYPE rpc_duration_seconds_count untyped\n"
         "rpc_duration_seconds_count 2693 0\n"
         ;
@@ -530,7 +521,6 @@ void test_skip_unsupported_types()
     TEST_CHECK(status == 0);
     result = cmt_encode_prometheus_create(cmt, CMT_TRUE);
     TEST_CHECK(strcmp(result,
-            "# HELP another_metric (no information)\n"
             "# TYPE another_metric untyped\n"
             "another_metric{key=\"abc\"} 32.399999999999999 0\n") == 0);
     cmt_sds_destroy(result);
@@ -649,7 +639,6 @@ void test_in_size()
     TEST_CHECK(status == 0);
     result = cmt_encode_prometheus_create(cmt, CMT_TRUE);
     TEST_CHECK(strcmp(result,
-                "# HELP metric_name (no information)\n"
                 "# TYPE metric_name untyped\n"
                 "metric_name{key=\"1\"} 1 0\n") == 0);
     cmt_sds_destroy(result);


### PR DESCRIPTION
This is necessary for prometheus compatibility, which has optional HELP section.
