### PR TITLE
msgpack: added histogram support to the msgpack encoder and decoder

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ The [CMetrics](https://github.com/calyptia/cmetrics) project is a standalone C l
 - Counters
 - Gauges
 - Histograms
+- Summaries
 
 This project is heavily based on Go Prometheus Client API design:
 

--- a/include/cmetrics/cmetrics.h
+++ b/include/cmetrics/cmetrics.h
@@ -26,7 +26,8 @@
 #define CMT_COUNTER   0
 #define CMT_GAUGE     1
 #define CMT_HISTOGRAM 2
-#define CMT_UNTYPED   3
+#define CMT_SUMMARY   3
+#define CMT_UNTYPED   4
 
 #define CMT_AGGREGATION_TYPE_UNSPECIFIED 0
 #define CMT_AGGREGATION_TYPE_DELTA       1
@@ -57,6 +58,7 @@ struct cmt {
     struct mk_list counters;
     struct mk_list gauges;
     struct mk_list histograms;
+    struct mk_list summaries;
     struct mk_list untypeds;
 };
 

--- a/include/cmetrics/cmt_decode_msgpack.h
+++ b/include/cmetrics/cmt_decode_msgpack.h
@@ -48,7 +48,8 @@ struct cmt_msgpack_decode_context {
     struct cmt        *cmt;
     struct cmt_map    *map;
     struct cmt_metric *metric;
-    struct mk_list     buckets;
+    double            *bucket_list;
+    size_t             bucket_count;
     struct mk_list     unique_label_list;
     int                static_labels_unpacked;
 };

--- a/include/cmetrics/cmt_decode_msgpack.h
+++ b/include/cmetrics/cmt_decode_msgpack.h
@@ -39,10 +39,16 @@
 #define CMT_DECODE_MSGPACK_DICTIONARY_LOOKUP_ERROR    CMT_MPACK_ERROR_CUTOFF + 1
 #define CMT_DECODE_MSGPACK_VERSION_ERROR              CMT_MPACK_ERROR_CUTOFF + 2
 
+struct cmt_msgpack_temporary_bucket {
+    double upper_bound;
+    struct mk_list _head;
+};
+
 struct cmt_msgpack_decode_context {
     struct cmt        *cmt;
     struct cmt_map    *map;
     struct cmt_metric *metric;
+    struct mk_list     buckets;
     struct mk_list     unique_label_list;
     int                static_labels_unpacked;
 };

--- a/include/cmetrics/cmt_histogram.h
+++ b/include/cmetrics/cmt_histogram.h
@@ -37,7 +37,8 @@ struct cmt_histogram {
 };
 
 /* Buckets */
-struct cmt_histogram_buckets *cmt_histogram_buckets_create(size_t count, double bucket, ...);
+struct cmt_histogram_buckets *cmt_histogram_buckets_create_size(double *bkts, size_t count);
+struct cmt_histogram_buckets *cmt_histogram_buckets_create(size_t count, ...);
 void cmt_histogram_buckets_destroy(struct cmt_histogram_buckets *buckets);
 
 struct cmt_histogram_buckets *cmt_histogram_buckets_default_create();

--- a/include/cmetrics/cmt_metric.h
+++ b/include/cmetrics/cmt_metric.h
@@ -31,6 +31,12 @@ struct cmt_metric {
     uint64_t hist_count;
     uint64_t hist_sum;
 
+    /* summary */
+    int sum_quantiles_set;     /* specify if quantive values has been set */
+    uint64_t sum_quantiles[5]; /* 0, 0.25, 0.5, 0.75 and 1 */
+    uint64_t sum_count;
+    uint64_t sum_sum;
+
     /* internal */
     uint64_t hash;
     uint64_t timestamp;

--- a/include/cmetrics/cmt_mpack_utils.h
+++ b/include/cmetrics/cmt_mpack_utils.h
@@ -42,6 +42,6 @@ int cmt_mpack_unpack_map(mpack_reader_t *reader,
 int cmt_mpack_unpack_array(mpack_reader_t *reader, 
                            cmt_mpack_unpacker_entry_callback_fn_t entry_processor_callback, 
                            void *context);
-
+int cmt_mpack_peek_array_length(mpack_reader_t *reader);
 
 #endif

--- a/include/cmetrics/cmt_summary.h
+++ b/include/cmetrics/cmt_summary.h
@@ -1,0 +1,62 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*  CMetrics
+ *  ========
+ *  Copyright 2021 Eduardo Silva <eduardo@calyptia.com>
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#ifndef CMT_SUMMARY_H
+#define CMT_SUMMARY_H
+
+#include <cmetrics/cmetrics.h>
+#include <cmetrics/cmt_opts.h>
+#include <cmetrics/cmt_metric.h>
+
+/*
+ * The structure only is aware about final 'quantile' values, not percentiles or
+ * any other involved variable. We won't do calculations.
+ */
+struct cmt_summary {
+    struct cmt_opts opts;
+    struct cmt_map *map;
+    struct mk_list _head;
+    struct cmt *cmt;
+};
+
+struct cmt_summary *cmt_summary_create(struct cmt *cmt,
+                                       char *ns, char *subsystem,
+                                       char *name, char *help,
+                                       int label_count, char **label_keys);
+
+int cmt_summary_destroy(struct cmt_summary *summary);
+
+int cmt_summary_set_default(struct cmt_summary *summary,
+                            uint64_t timestamp,
+                            double quantiles_default[5],
+                            double sum,
+                            uint64_t count,
+                            int labels_count, char **label_vars);
+
+/* quantiles */
+double cmt_summary_quantile_get_value(struct cmt_metric *metric, int quantile_id);
+
+double cmt_summary_get_sum_value(struct cmt_metric *metric);
+uint64_t cmt_summary_get_count_value(struct cmt_metric *metric);
+
+void cmt_summary_quantile_set(struct cmt_metric *metric, uint64_t timestamp,
+                              int quantile_id, double val);
+
+
+#endif

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -13,6 +13,7 @@ set(src
   cmt_gauge.c
   cmt_counter.c
   cmt_untyped.c
+  cmt_summary.c
   cmt_histogram.c
   cmt_metric.c
   cmt_metric_histogram.c

--- a/src/cmetrics.c
+++ b/src/cmetrics.c
@@ -21,6 +21,7 @@
 #include <cmetrics/cmt_log.h>
 #include <cmetrics/cmt_counter.h>
 #include <cmetrics/cmt_gauge.h>
+#include <cmetrics/cmt_summary.h>
 #include <cmetrics/cmt_histogram.h>
 #include <cmetrics/cmt_untyped.h>
 #include <cmetrics/cmt_atomic.h>
@@ -54,6 +55,7 @@ struct cmt *cmt_create()
     mk_list_init(&cmt->counters);
     mk_list_init(&cmt->gauges);
     mk_list_init(&cmt->histograms);
+    mk_list_init(&cmt->summaries);
     mk_list_init(&cmt->untypeds);
 
     cmt->log_level = CMT_LOG_ERROR;
@@ -67,6 +69,7 @@ void cmt_destroy(struct cmt *cmt)
     struct mk_list *head;
     struct cmt_counter *c;
     struct cmt_gauge *g;
+    struct cmt_summary *s;
     struct cmt_histogram *h;
     struct cmt_untyped *u;
 
@@ -78,6 +81,11 @@ void cmt_destroy(struct cmt *cmt)
     mk_list_foreach_safe(head, tmp, &cmt->gauges) {
         g = mk_list_entry(head, struct cmt_gauge, _head);
         cmt_gauge_destroy(g);
+    }
+
+    mk_list_foreach_safe(head, tmp, &cmt->summaries) {
+        s = mk_list_entry(head, struct cmt_summary, _head);
+        cmt_summary_destroy(s);
     }
 
     mk_list_foreach_safe(head, tmp, &cmt->histograms) {

--- a/src/cmt_decode_msgpack.c
+++ b/src/cmt_decode_msgpack.c
@@ -879,13 +879,12 @@ static int unpack_basic_type_meta(mpack_reader_t *reader, size_t index, void *co
         if (decode_context->map->type == CMT_HISTOGRAM) {
             histogram = (struct cmt_histogram *) decode_context->map->parent;
 
-            result = initialize_histogram_bucket_list(histogram,
-                                                      decode_context->bucket_list,
-                                                      decode_context->bucket_count);
+            histogram->buckets =
+                cmt_histogram_buckets_create_size(decode_context->bucket_list,
+                                                  decode_context->bucket_count);
 
-            if (CMT_DECODE_MSGPACK_SUCCESS == result) {
-                decode_context->bucket_list = NULL;
-                decode_context->bucket_count = 0;
+            if (histogram->buckets == NULL) {
+                result = CMT_DECODE_MSGPACK_ALLOCATION_ERROR;
             }
         }
     }

--- a/src/cmt_decode_msgpack.c
+++ b/src/cmt_decode_msgpack.c
@@ -293,31 +293,29 @@ static int unpack_bucket(mpack_reader_t *reader,
 {
     int                                  result;
     struct cmt_msgpack_temporary_bucket *new_bucket;
-    uint64_t                             upper_bound;
 
     if (NULL == reader      ||
         NULL == bucket_list ) {
         return CMT_DECODE_MSGPACK_INVALID_ARGUMENT_ERROR;
     }
 
-    result = cmt_mpack_consume_uint_tag(reader, &upper_bound);
-
-    if (CMT_DECODE_MSGPACK_SUCCESS != result) {
-        return result;
-    }
-
     new_bucket = calloc(1, sizeof(struct cmt_msgpack_temporary_bucket));
 
     if (NULL == new_bucket) {
-        return CMT_DECODE_MSGPACK_ALLOCATION_ERROR;
+        result = CMT_DECODE_MSGPACK_ALLOCATION_ERROR;
     }
     else {
-        new_bucket->upper_bound = cmt_math_uint64_to_d64(upper_bound);
+        result = cmt_mpack_consume_double_tag(reader, &new_bucket->upper_bound);
 
-        mk_list_add(&new_bucket->_head, bucket_list);
+        if (CMT_DECODE_MSGPACK_SUCCESS == result) {
+            mk_list_add(&new_bucket->_head, bucket_list);
+        }
+        else {
+            free(new_bucket);
+        }
     }
 
-    return CMT_DECODE_MSGPACK_SUCCESS;
+    return result;
 }
 
 static int unpack_label(mpack_reader_t *reader,
@@ -551,8 +549,6 @@ static int unpack_metric_count(mpack_reader_t *reader, size_t index, void *conte
 static int unpack_metric_bucket(mpack_reader_t *reader, size_t index, void *context)
 {
     struct cmt_msgpack_decode_context *decode_context;
-    int                                result;
-    double                             value;
 
     if (NULL == reader ||
         NULL == context) {
@@ -561,13 +557,7 @@ static int unpack_metric_bucket(mpack_reader_t *reader, size_t index, void *cont
 
     decode_context = (struct cmt_msgpack_decode_context *) context;
 
-    result = cmt_mpack_consume_double_tag(reader, &value);
-
-    if (result == CMT_DECODE_MSGPACK_SUCCESS) {
-        decode_context->metric->hist_buckets[index] = cmt_math_d64_to_uint64(value);
-    }
-
-    return result;
+    return cmt_mpack_consume_uint_tag(reader, &decode_context->metric->hist_buckets[index]);
 }
 
 static int unpack_metric_buckets(mpack_reader_t *reader, size_t index, void *context)
@@ -582,6 +572,20 @@ static int unpack_metric_buckets(mpack_reader_t *reader, size_t index, void *con
     decode_context = (struct cmt_msgpack_decode_context *) context;
 
     return cmt_mpack_unpack_array(reader, unpack_metric_bucket, context);
+}
+
+static int unpack_metric_hash(mpack_reader_t *reader, size_t index, void *context)
+{
+    struct cmt_msgpack_decode_context *decode_context;
+
+    if (NULL == reader  ||
+        NULL == context ) {
+        return CMT_DECODE_MSGPACK_INVALID_ARGUMENT_ERROR;
+    }
+
+    decode_context = (struct cmt_msgpack_decode_context *) context;
+
+    return cmt_mpack_consume_uint_tag(reader, &decode_context->metric->hash);
 }
 
 static int unpack_metric(mpack_reader_t *reader,
@@ -599,6 +603,7 @@ static int unpack_metric(mpack_reader_t *reader,
             {"sum",     unpack_metric_sum},
             {"count",   unpack_metric_count},
             {"buckets", unpack_metric_buckets},
+            {"hash",    unpack_metric_hash},
             {NULL,     NULL}
         };
 
@@ -661,8 +666,6 @@ static int unpack_metric_array_entry(mpack_reader_t *reader, size_t index, void 
         return CMT_DECODE_MSGPACK_INVALID_ARGUMENT_ERROR;
     }
 
-printf("DECODING METRIC\n");
-
     decode_context = (struct cmt_msgpack_decode_context *) context;
 
     metric = NULL;
@@ -691,13 +694,7 @@ printf("DECODING METRIC\n");
         else
         {
             mk_list_add(&metric->_head, &decode_context->map->metrics);
-            printf("ADDING TO METRICS\n");
         }
-    }
-    else
-    {
-        printf("FAILURE DECODING METRICS : %d\n", result);
-        exit(0);
     }
 
     return result;

--- a/src/cmt_encode_msgpack.c
+++ b/src/cmt_encode_msgpack.c
@@ -260,6 +260,7 @@ static void pack_header(mpack_writer_t *writer, struct cmt *cmt, struct cmt_map 
     if (map->type == CMT_HISTOGRAM) {
         /* 'buckets' (histogram buckets) */
         mpack_write_cstr(writer, "buckets");
+
         mpack_start_array(writer, histogram->buckets->count);
 
         for (bucket_index = 0 ;
@@ -452,9 +453,14 @@ int cmt_encode_msgpack_create(struct cmt *cmt, char **out_buf, size_t *out_size)
      *      }
      *  , ...]
      *
+     *
+     * The following fields are metric type specific and are only
+     * included for histograms :
+     *      meta->buckets
+     *      values[n]->buckets
+     *      values[n]->count
+     *      values[n]->sum
      */
-
-
 
     mpack_writer_init_growable(&writer, &data, &size);
 

--- a/src/cmt_mpack_utils.c
+++ b/src/cmt_mpack_utils.c
@@ -161,7 +161,6 @@ int cmt_mpack_unpack_map(mpack_reader_t *reader,
 
         if (CMT_MPACK_SUCCESS == result) {
             callback_entry = callback_list;
-
             result = CMT_MPACK_UNEXPECTED_KEY_ERROR;
 
             while (CMT_MPACK_UNEXPECTED_KEY_ERROR == result &&
@@ -187,7 +186,7 @@ int cmt_mpack_unpack_map(mpack_reader_t *reader,
         }
     }
 
-    return CMT_MPACK_SUCCESS;
+    return result;
 }
 
 int cmt_mpack_unpack_array(mpack_reader_t *reader,
@@ -246,7 +245,7 @@ int cmt_mpack_unpack_array(mpack_reader_t *reader,
         }
     }
 
-    return 0;
+    return result;
 }
 
 int cmt_mpack_peek_array_length(mpack_reader_t *reader)

--- a/src/cmt_mpack_utils.c
+++ b/src/cmt_mpack_utils.c
@@ -248,3 +248,21 @@ int cmt_mpack_unpack_array(mpack_reader_t *reader,
 
     return 0;
 }
+
+int cmt_mpack_peek_array_length(mpack_reader_t *reader)
+{
+    mpack_tag_t tag;
+
+    tag = mpack_peek_tag(reader);
+
+    if (mpack_ok != mpack_reader_error(reader))
+    {
+        return 0;
+    }
+
+    if (mpack_type_array != mpack_tag_type(&tag)) {
+        return 0;
+    }
+
+    return mpack_tag_array_count(&tag);
+}

--- a/src/cmt_summary.c
+++ b/src/cmt_summary.c
@@ -1,0 +1,273 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*  CMetrics
+ *  ========
+ *  Copyright 2021 Eduardo Silva <eduardo@calyptia.com>
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#include <cmetrics/cmetrics.h>
+#include <cmetrics/cmt_log.h>
+#include <cmetrics/cmt_map.h>
+#include <cmetrics/cmt_math.h>
+#include <cmetrics/cmt_atomic.h>
+#include <cmetrics/cmt_metric.h>
+#include <cmetrics/cmt_summary.h>
+
+#include <stdarg.h>
+
+/*
+ * CMetrics 'Summary' metric type is only a container for values reported by a
+ * scrapper. We don't do data observation or calculate values for quantiles, we
+ * just compose a structure to keep the reported values.
+ *
+ * This metric type uses very similar 'Histogram' structures and interfaces.
+ */
+
+struct cmt_summary *cmt_summary_create(struct cmt *cmt,
+                                       char *ns, char *subsystem,
+                                       char *name, char *help,
+                                       int label_count, char **label_keys)
+{
+    int ret;
+    struct cmt_summary *s;
+
+    if (!ns) {
+        cmt_log_error(cmt, "null ns not allowed");
+        return NULL;
+    }
+
+    if (!subsystem) {
+        cmt_log_error(cmt, "null subsystem not allowed");
+        return NULL;
+    }
+
+    if (!name || strlen(name) == 0) {
+        cmt_log_error(cmt, "undefined name");
+        return NULL;
+    }
+
+    if (!help || strlen(help) == 0) {
+        cmt_log_error(cmt, "undefined help");
+        return NULL;
+    }
+
+    s = calloc(1, sizeof(struct cmt_summary));
+    if (!s) {
+        cmt_errno();
+        return NULL;
+    }
+    mk_list_add(&s->_head, &cmt->summaries);
+
+    /* initialize options */
+    ret = cmt_opts_init(&s->opts, ns, subsystem, name, help);
+    if (ret == -1) {
+        cmt_log_error(cmt, "unable to initialize options for summary");
+        cmt_summary_destroy(s);
+        return NULL;
+    }
+
+    /* Create the map */
+    s->map = cmt_map_create(CMT_SUMMARY, &s->opts, label_count, label_keys,
+                            (void *) s);
+    if (!s->map) {
+        cmt_log_error(cmt, "unable to allocate map for summary");
+        cmt_summary_destroy(s);
+        return NULL;
+    }
+
+    return s;
+}
+
+int cmt_summary_destroy(struct cmt_summary *summary)
+{
+    mk_list_del(&summary->_head);
+    cmt_opts_exit(&summary->opts);
+
+    if (summary->map) {
+        cmt_map_destroy(summary->map);
+    }
+
+    free(summary);
+    return 0;
+}
+
+double cmt_summary_quantile_get_value(struct cmt_metric *metric, int quantile_id)
+{
+    uint64_t val;
+
+    if (quantile_id < 0 || quantile_id > 5) {
+        return 0;
+    }
+
+    val = cmt_atomic_load(&metric->sum_quantiles[quantile_id]);
+    return cmt_math_uint64_to_d64(val);
+}
+
+double cmt_summary_get_sum_value(struct cmt_metric *metric)
+{
+    uint64_t val;
+
+    val = cmt_atomic_load(&metric->sum_sum);
+    return cmt_math_uint64_to_d64(val);
+}
+
+uint64_t cmt_summary_get_count_value(struct cmt_metric *metric)
+{
+    uint64_t val;
+
+    val = cmt_atomic_load(&metric->sum_count);
+    return val;
+}
+
+static inline int summary_quantile_exchange(struct cmt_metric *metric,
+                                            uint64_t timestamp,
+                                            int quantile_id,
+                                            double new_value, double old_value)
+{
+    uint64_t tmp_new;
+    uint64_t tmp_old;
+    int      result;
+
+    tmp_new = cmt_math_d64_to_uint64(new_value);
+    tmp_old = cmt_math_d64_to_uint64(old_value);
+
+    result = cmt_atomic_compare_exchange(&metric->sum_quantiles[quantile_id],
+                                         tmp_old, tmp_new);
+
+    if (result == 0) {
+        return 0;
+    }
+
+    cmt_atomic_store(&metric->timestamp, timestamp);
+    return 1;
+}
+
+static inline int summary_sum_exchange(struct cmt_metric *metric,
+                                       uint64_t timestamp,
+                                       double new_value, double old_value)
+{
+    uint64_t tmp_new;
+    uint64_t tmp_old;
+    int      result;
+
+    tmp_new = cmt_math_d64_to_uint64(new_value);
+    tmp_old = cmt_math_d64_to_uint64(old_value);
+
+    result = cmt_atomic_compare_exchange(&metric->sum_sum, tmp_old, tmp_new);
+
+    if (result == 0) {
+        return 0;
+    }
+
+    cmt_atomic_store(&metric->timestamp, timestamp);
+    return 1;
+}
+
+static inline int summary_count_exchange(struct cmt_metric *metric,
+                                         uint64_t timestamp,
+                                         uint64_t new, uint64_t old)
+{
+    int result;
+
+    result = cmt_atomic_compare_exchange(&metric->sum_count, old, new);
+    if (result == 0) {
+        return 0;
+    }
+
+    cmt_atomic_store(&metric->timestamp, timestamp);
+    return 1;
+}
+
+void cmt_summary_quantile_set(struct cmt_metric *metric, uint64_t timestamp,
+                              int quantile_id, double val)
+{
+    double   old;
+    double   new;
+    int      result;
+
+    do {
+        old = cmt_summary_quantile_get_value(metric, quantile_id);
+        new = val;
+        result = summary_quantile_exchange(metric, timestamp, quantile_id, new, old);
+    }
+    while (0 == result);
+}
+
+void cmt_summary_sum_set(struct cmt_metric *metric, uint64_t timestamp, double val)
+{
+    double   old;
+    double   new;
+    int      result;
+
+    do {
+        old = cmt_summary_get_sum_value(metric);
+        new = val;
+        result = summary_sum_exchange(metric, timestamp, new, old);
+    }
+    while (0 == result);
+}
+
+void cmt_summary_count_set(struct cmt_metric *metric, uint64_t timestamp,
+                           uint64_t count)
+{
+    int result;
+    uint64_t old;
+    uint64_t new;
+
+    do {
+        old = cmt_atomic_load(&metric->sum_count);
+        new = count;
+
+        result = summary_count_exchange(metric, timestamp, new, old);
+    }
+    while (result == 0);
+}
+
+int cmt_summary_set_default(struct cmt_summary *summary,
+                            uint64_t timestamp,
+                            double *quantiles_default,
+                            double sum,
+                            uint64_t count,
+                            int labels_count, char **label_vars)
+{
+    int i;
+    struct cmt_metric *metric;
+
+    metric = cmt_map_metric_get(&summary->opts, summary->map,
+                                labels_count, label_vars,
+                                CMT_TRUE);
+    if (!metric) {
+        cmt_log_error(summary->cmt, "unable to retrieve metric: %s for summary %s_%s_%s",
+                      summary->map, summary->opts.ns, summary->opts.subsystem,
+                      summary->opts.name);
+        return -1;
+    }
+
+    /* set quantile values */
+    if (quantiles_default) {
+        /* yes, quantile values are set */
+        metric->sum_quantiles_set = CMT_TRUE;
+
+        /* populate each quantile */
+        for (i = 0; i < 5; i++) {
+            cmt_summary_quantile_set(metric, timestamp, i, quantiles_default[i]);
+        }
+    }
+
+    cmt_summary_sum_set(metric, timestamp, sum);
+    cmt_summary_count_set(metric, timestamp, count);
+
+    return 0;
+}

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -2,6 +2,7 @@ set(UNIT_TESTS_FILES
   basic.c
   gauge.c
   counter.c
+  summary.c
   histogram.c
   untyped.c
   atomic_operations.c

--- a/tests/encoding.c
+++ b/tests/encoding.c
@@ -16,10 +16,14 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
+#ifdef __GNUC__
+#define _GNU_SOURCE
+#endif
 
 #include <cmetrics/cmetrics.h>
 #include <cmetrics/cmt_gauge.h>
 #include <cmetrics/cmt_counter.h>
+#include <cmetrics/cmt_histogram.h>
 #include <cmetrics/cmt_encode_msgpack.h>
 #include <cmetrics/cmt_decode_msgpack.h>
 #include <cmetrics/cmt_encode_prometheus_remote_write.h>
@@ -68,6 +72,8 @@ static struct cmt *generate_encoder_test_data()
     struct cmt_counter *c1;
     struct cmt_counter *c2;
     struct cmt_counter *c3;
+    struct cmt_histogram *h1;
+    struct cmt_histogram_buckets *buckets;
 
     cmt = cmt_create();
 
@@ -110,6 +116,33 @@ static struct cmt *generate_encoder_test_data()
     c3 = cmt_counter_create(cmt, "kubernetes", "", "cpu", "CPU load",
                             2, (char *[]) {"hostname", "app"});
     cmt_counter_set(c3, ts, 10, 0, NULL);
+
+    /* Create buckets */
+    buckets = cmt_histogram_buckets_create(3, 0.05, 5.0, 10.0);
+    TEST_CHECK(buckets != NULL);
+
+    /* Create a gauge metric type */
+    h1 = cmt_histogram_create(cmt,
+                              "k8s", "network", "load", "Network load",
+                              buckets,
+                              1, (char *[]) {"my_label"});
+    TEST_CHECK(h1 != NULL);
+
+    ts = 0;
+
+    /* no labels */
+    cmt_histogram_observe(h1, ts, 0.001, 0, NULL);
+    cmt_histogram_observe(h1, ts, 0.020, 0, NULL);
+    cmt_histogram_observe(h1, ts, 5.0, 0, NULL);
+    cmt_histogram_observe(h1, ts, 8.0, 0, NULL);
+    cmt_histogram_observe(h1, ts, 1000, 0, NULL);
+
+    /* defined labels: add a custom label value */
+    cmt_histogram_observe(h1, ts, 0.001, 1, (char *[]) {"my_val"});
+    cmt_histogram_observe(h1, ts, 0.020, 1, (char *[]) {"my_val"});
+    cmt_histogram_observe(h1, ts, 5.0, 1, (char *[]) {"my_val"});
+    cmt_histogram_observe(h1, ts, 8.0, 1, (char *[]) {"my_val"});
+    cmt_histogram_observe(h1, ts, 1000, 1, (char *[]) {"my_val"});;
 
     return cmt;
 }
@@ -159,6 +192,65 @@ void test_cmt_to_msgpack()
     cmt_decode_msgpack_destroy(cmt2);
     cmt_encode_msgpack_destroy(mp1_buf);
     cmt_encode_msgpack_destroy(mp2_buf);
+}
+
+/*
+ * Encode a context, corrupt the last metric in the msgpack packet
+ * and invoke the decoder to verify if there are any leaks.
+ *
+ * CMT -> MSGPACK -> CMT
+ *
+ * Note: this function is meant to be executed in linux while using
+ * valgrind
+ */
+
+void test_cmt_to_msgpack_cleanup_on_error()
+{
+#ifdef __linux__
+    int ret;
+    size_t offset = 0;
+    char *mp1_buf = NULL;
+    size_t mp1_size = 0;
+    char *mp2_buf = NULL;
+    size_t mp2_size = 0;
+    struct cmt *cmt1 = NULL;
+    struct cmt *cmt2 = NULL;
+    char *key_buffer = NULL;
+    char *key_haystack = NULL;
+
+    cmt_initialize();
+
+    /* Generate context with data */
+    cmt1 = generate_encoder_test_data();
+    TEST_CHECK(cmt1 != NULL);
+
+    /* CMT1 -> Msgpack */
+    ret = cmt_encode_msgpack_create(cmt1, &mp1_buf, &mp1_size);
+    TEST_CHECK(ret == 0);
+
+    key_haystack = &mp1_buf[mp1_size - 32];
+    key_buffer = memmem(key_haystack, 32, "hash", 4);
+
+    TEST_CHECK(key_buffer != NULL);
+
+    /* This turns the last 'hash' entry into 'hasq' which causes
+     * the map consumer in the decoder to detect an unprocessed entry
+     * and abort in `unpack_metric` which means a lot of allocations
+     * have been made including but not limited to temporary
+     * histogram bucket arrays and completely decoded histograms
+     */
+    key_buffer[3] = 'q';
+
+    /* Msgpack -> CMT2 */
+    ret = cmt_decode_msgpack_create(&cmt2, mp1_buf, mp1_size, &offset);
+
+    cmt_destroy(cmt1);
+    cmt_encode_msgpack_destroy(mp1_buf);
+
+    TEST_CHECK(ret != 0);
+    TEST_CHECK(cmt2 == NULL);
+
+#endif
 }
 
 /*
@@ -666,6 +758,7 @@ void test_influx()
 }
 
 TEST_LIST = {
+    {"cmt_msgpack_cleanup_on_error",   test_cmt_to_msgpack_cleanup_on_error},
     {"cmt_msgpack_partial_processing", test_cmt_msgpack_partial_processing},
     {"prometheus_remote_write",        test_prometheus_remote_write},
     {"cmt_msgpack_stability",          test_cmt_to_msgpack_stability},

--- a/tests/summary.c
+++ b/tests/summary.c
@@ -1,0 +1,88 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*  CMetrics
+ *  ========
+ *  Copyright 2021 Eduardo Silva <eduardo@calyptia.com>
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#include <cmetrics/cmetrics.h>
+#include <cmetrics/cmt_summary.h>
+#include <cmetrics/cmt_encode_prometheus.h>
+
+#include "cmt_tests.h"
+
+static void prometheus_encode_test(struct cmt *cmt)
+{
+    cmt_sds_t buf;
+
+    buf = cmt_encode_prometheus_create(cmt, CMT_FALSE);
+    printf("\n%s\n", buf);
+    cmt_encode_prometheus_destroy(buf);
+}
+
+void test_set_defaults()
+{
+    int ret;
+    double val;
+    double sum;
+    uint64_t count;
+    uint64_t ts;
+    double q[5];
+    struct cmt *cmt;
+    struct cmt_summary *s;
+
+    cmt_initialize();
+
+    /* Timestamp */
+    ts = cmt_time_now();
+
+    /* CMetrics context */
+    cmt = cmt_create();
+    TEST_CHECK(cmt != NULL);
+
+    /* Create a gauge metric type */
+    s = cmt_summary_create(cmt,
+                           "k8s", "network", "load", "Network load",
+                           1, (char *[]) {"my_label"});
+    TEST_CHECK(s != NULL);
+
+    count = 10;
+    sum   = 51.612894511314444;
+
+    /* no quantiles, no labels */
+    cmt_summary_set_default(s, ts, NULL, sum, count, 0, NULL);
+    prometheus_encode_test(cmt);
+
+    /* set quantiles, no labels */
+    q[0] = 0.1;
+    q[1] = 0.2;
+    q[2] = 0.3;
+    q[3] = 0.4;
+    q[4] = 0.5;
+
+    cmt_summary_set_default(s, ts, q, sum, count, 0, NULL);
+    prometheus_encode_test(cmt);
+
+    /* static label: register static label for the context */
+    cmt_label_add(cmt, "static", "test");
+    prometheus_encode_test(cmt);
+
+    cmt_destroy(cmt);
+}
+
+TEST_LIST = {
+    {"set_defaults", test_set_defaults},
+    { 0 }
+};


### PR DESCRIPTION
This is a work in progress, at the moment there is still a small discrepancy in the regenerated data so it's not ready to be merged.

Signed-off-by: Leonardo Alminana <leonardo@calyptia.com>