### PR TITLE
msgpack: histogram support addition

### DIFF
--- a/include/cmetrics/cmt_decode_msgpack.h
+++ b/include/cmetrics/cmt_decode_msgpack.h
@@ -39,10 +39,17 @@
 #define CMT_DECODE_MSGPACK_DICTIONARY_LOOKUP_ERROR    CMT_MPACK_ERROR_CUTOFF + 1
 #define CMT_DECODE_MSGPACK_VERSION_ERROR              CMT_MPACK_ERROR_CUTOFF + 2
 
+struct cmt_msgpack_temporary_bucket {
+    double upper_bound;
+    struct mk_list _head;
+};
+
 struct cmt_msgpack_decode_context {
     struct cmt        *cmt;
     struct cmt_map    *map;
     struct cmt_metric *metric;
+    double            *bucket_list;
+    size_t             bucket_count;
     struct mk_list     unique_label_list;
     int                static_labels_unpacked;
 };

--- a/include/cmetrics/cmt_mpack_utils.h
+++ b/include/cmetrics/cmt_mpack_utils.h
@@ -42,6 +42,6 @@ int cmt_mpack_unpack_map(mpack_reader_t *reader,
 int cmt_mpack_unpack_array(mpack_reader_t *reader, 
                            cmt_mpack_unpacker_entry_callback_fn_t entry_processor_callback, 
                            void *context);
-
+int cmt_mpack_peek_array_length(mpack_reader_t *reader);
 
 #endif

--- a/src/cmt_decode_msgpack.c
+++ b/src/cmt_decode_msgpack.c
@@ -21,6 +21,7 @@
 #include <cmetrics/cmt_metric.h>
 #include <cmetrics/cmt_map.h>
 #include <cmetrics/cmt_sds.h>
+#include <cmetrics/cmt_histogram.h>
 #include <cmetrics/cmt_counter.h>
 #include <cmetrics/cmt_gauge.h>
 #include <cmetrics/cmt_untyped.h>
@@ -28,6 +29,121 @@
 #include <cmetrics/cmt_encode_msgpack.h>
 #include <cmetrics/cmt_decode_msgpack.h>
 #include <cmetrics/cmt_mpack_utils.h>
+
+static void destroy_temporary_bucket_list(struct mk_list *bucket_list)
+{
+    struct mk_list                      *tmp;
+    struct mk_list                      *head;
+    struct cmt_msgpack_temporary_bucket *bucket;
+
+    mk_list_foreach_safe(head, tmp, bucket_list) {
+        bucket = mk_list_entry(head, struct cmt_msgpack_temporary_bucket, _head);
+
+        mk_list_del(&bucket->_head);
+
+        free(bucket);
+    }
+}
+
+static int create_counter_instance(struct cmt_map *map)
+{
+    struct cmt_counter *counter;
+
+    if (NULL == map) {
+        return CMT_DECODE_MSGPACK_INVALID_ARGUMENT_ERROR;
+    }
+
+    counter = calloc(1, sizeof(struct cmt_counter));
+
+    if (NULL == counter) {
+        return CMT_DECODE_MSGPACK_ALLOCATION_ERROR;
+    }
+
+    counter->map = map;
+
+    map->parent = (void *) counter;
+
+    return CMT_DECODE_MSGPACK_SUCCESS;
+}
+
+static int create_gauge_instance(struct cmt_map *map)
+{
+    struct cmt_gauge *gauge;
+
+    if (NULL == map) {
+        return CMT_DECODE_MSGPACK_INVALID_ARGUMENT_ERROR;
+    }
+
+    gauge = calloc(1, sizeof(struct cmt_gauge));
+
+    if (NULL == gauge) {
+        return CMT_DECODE_MSGPACK_ALLOCATION_ERROR;
+    }
+
+    gauge->map = map;
+
+    map->parent = (void *) gauge;
+
+    return CMT_DECODE_MSGPACK_SUCCESS;
+}
+
+static int create_untyped_instance(struct cmt_map *map)
+{
+    struct cmt_untyped *untyped;
+
+    if (NULL == map) {
+        return CMT_DECODE_MSGPACK_INVALID_ARGUMENT_ERROR;
+    }
+
+    untyped = calloc(1, sizeof(struct cmt_untyped));
+
+    if (NULL == untyped) {
+        return CMT_DECODE_MSGPACK_ALLOCATION_ERROR;
+    }
+
+    untyped->map = map;
+
+    map->parent = (void *) untyped;
+
+    return CMT_DECODE_MSGPACK_SUCCESS;
+}
+
+static int create_histogram_instance(struct cmt_map *map)
+{
+    struct cmt_histogram *histogram;
+
+    if (NULL == map) {
+        return CMT_DECODE_MSGPACK_INVALID_ARGUMENT_ERROR;
+    }
+
+    histogram = calloc(1, sizeof(struct cmt_histogram));
+
+    if (NULL == histogram) {
+        return CMT_DECODE_MSGPACK_ALLOCATION_ERROR;
+    }
+
+    histogram->map = map;
+
+    map->parent = (void *) histogram;
+
+    return CMT_DECODE_MSGPACK_SUCCESS;
+}
+
+static int create_metric_instance(struct cmt_map *map)
+{
+    switch(map->type) {
+        case CMT_COUNTER:
+            return create_counter_instance(map);
+        case CMT_GAUGE:
+            return create_gauge_instance(map);
+        case CMT_HISTOGRAM:
+            return create_histogram_instance(map);
+        case CMT_UNTYPED:
+            return create_untyped_instance(map);
+    }
+
+    return CMT_DECODE_MSGPACK_INVALID_ARGUMENT_ERROR;
+}
 
 static struct cmt_map_label *find_label_by_index(struct mk_list *label_list, size_t desired_index)
 {
@@ -219,7 +335,8 @@ static int unpack_label(mpack_reader_t *reader,
     return CMT_DECODE_MSGPACK_SUCCESS;
 }
 
-static int unpack_static_label(mpack_reader_t *reader, size_t index, void *context)
+static int unpack_static_label(mpack_reader_t *reader,
+                               size_t index, void *context)
 {
     struct mk_list                    *target_label_list;
     struct mk_list                    *unique_label_list;
@@ -363,17 +480,100 @@ static int unpack_metric_labels(mpack_reader_t *reader, size_t index, void *cont
                                   context);
 }
 
+static int unpack_metric_sum(mpack_reader_t *reader, size_t index, void *context)
+{
+    struct cmt_msgpack_decode_context *decode_context;
+    int                                result;
+    double                             value;
+
+    if (NULL == reader  ||
+        NULL == context ) {
+        return CMT_DECODE_MSGPACK_INVALID_ARGUMENT_ERROR;
+    }
+
+    decode_context = (struct cmt_msgpack_decode_context *) context;
+
+    result = cmt_mpack_consume_double_tag(reader, &value);
+
+    if (result == CMT_DECODE_MSGPACK_SUCCESS) {
+        decode_context->metric->hist_sum = cmt_math_d64_to_uint64(value);
+    }
+
+    return result;
+}
+
+static int unpack_metric_count(mpack_reader_t *reader, size_t index, void *context)
+{
+    struct cmt_msgpack_decode_context *decode_context;
+
+    if (NULL == reader  ||
+        NULL == context ) {
+        return CMT_DECODE_MSGPACK_INVALID_ARGUMENT_ERROR;
+    }
+
+    decode_context = (struct cmt_msgpack_decode_context *) context;
+
+    return cmt_mpack_consume_uint_tag(reader, &decode_context->metric->hist_count);
+}
+
+static int unpack_metric_bucket(mpack_reader_t *reader, size_t index, void *context)
+{
+    struct cmt_msgpack_decode_context *decode_context;
+
+    if (NULL == reader ||
+        NULL == context) {
+        return CMT_DECODE_MSGPACK_INVALID_ARGUMENT_ERROR;
+    }
+
+    decode_context = (struct cmt_msgpack_decode_context *) context;
+
+    return cmt_mpack_consume_uint_tag(reader, &decode_context->metric->hist_buckets[index]);
+}
+
+static int unpack_metric_buckets(mpack_reader_t *reader, size_t index, void *context)
+{
+    struct cmt_msgpack_decode_context *decode_context;
+
+    if (NULL == reader  ||
+        NULL == context ) {
+        return CMT_DECODE_MSGPACK_INVALID_ARGUMENT_ERROR;
+    }
+
+    decode_context = (struct cmt_msgpack_decode_context *) context;
+
+    return cmt_mpack_unpack_array(reader, unpack_metric_bucket, context);
+}
+
+static int unpack_metric_hash(mpack_reader_t *reader, size_t index, void *context)
+{
+    struct cmt_msgpack_decode_context *decode_context;
+
+    if (NULL == reader  ||
+        NULL == context ) {
+        return CMT_DECODE_MSGPACK_INVALID_ARGUMENT_ERROR;
+    }
+
+    decode_context = (struct cmt_msgpack_decode_context *) context;
+
+    return cmt_mpack_consume_uint_tag(reader, &decode_context->metric->hash);
+}
+
 static int unpack_metric(mpack_reader_t *reader,
                          struct cmt_msgpack_decode_context *decode_context,
                          struct cmt_metric **out_metric)
 {
     int                                   result;
     struct cmt_metric                    *metric;
+    struct cmt_histogram                 *histogram;
     struct cmt_mpack_map_entry_callback_t callbacks[] = \
         {
-            {"ts",     unpack_metric_ts},
-            {"value",  unpack_metric_value},
-            {"labels", unpack_metric_labels},
+            {"ts",      unpack_metric_ts},
+            {"value",   unpack_metric_value},
+            {"labels",  unpack_metric_labels},
+            {"sum",     unpack_metric_sum},
+            {"count",   unpack_metric_count},
+            {"buckets", unpack_metric_buckets},
+            {"hash",    unpack_metric_hash},
             {NULL,     NULL}
         };
 
@@ -393,6 +593,20 @@ static int unpack_metric(mpack_reader_t *reader,
         return CMT_DECODE_MSGPACK_ALLOCATION_ERROR;
     }
 
+    if (decode_context->map->type == CMT_HISTOGRAM) {
+        histogram = decode_context->map->parent;
+
+        metric->hist_buckets = calloc(histogram->buckets->count, sizeof(uint64_t));
+
+        if (metric->hist_buckets == NULL) {
+            cmt_errno();
+
+            free(metric);
+
+            return CMT_DECODE_MSGPACK_ALLOCATION_ERROR;
+        }
+    }
+
     mk_list_init(&metric->labels);
 
     decode_context->metric = metric;
@@ -401,6 +615,10 @@ static int unpack_metric(mpack_reader_t *reader,
 
     if (CMT_DECODE_MSGPACK_SUCCESS != result) {
         destroy_label_list(&metric->labels);
+
+        if (NULL != metric->hist_buckets) {
+            free(metric->hist_buckets);
+        }
 
         free(metric);
     }
@@ -432,12 +650,18 @@ static int unpack_metric_array_entry(mpack_reader_t *reader, size_t index, void 
             /* Should we care about finding more than one "implicitly static metric" in
              * the array?
              */
-
             decode_context->map->metric_static_set = 1;
 
-            decode_context->map->metric.val = metric->val;
-            decode_context->map->metric.hash = metric->hash;
-            decode_context->map->metric.timestamp = metric->timestamp;
+            if (decode_context->map->type == CMT_HISTOGRAM) {
+                decode_context->map->metric.hist_buckets = metric->hist_buckets;
+                decode_context->map->metric.hist_count = metric->hist_count;
+                decode_context->map->metric.hist_sum = metric->hist_sum;
+            }
+            else {
+                decode_context->map->metric.val = metric->val;
+                decode_context->map->metric.hash = metric->hash;
+                decode_context->map->metric.timestamp = metric->timestamp;
+            }
 
             free(metric);
         }
@@ -488,6 +712,8 @@ static int unpack_meta_type(mpack_reader_t *reader, size_t index, void *context)
 
     if (CMT_DECODE_MSGPACK_SUCCESS == result) {
         decode_context->map->type = value;
+
+        result = create_metric_instance(decode_context->map);
     }
 
     return result;
@@ -568,9 +794,67 @@ static int unpack_meta_labels(mpack_reader_t *reader, size_t index, void *contex
     return cmt_mpack_unpack_array(reader, unpack_meta_label, context);
 }
 
+static int unpack_meta_bucket(mpack_reader_t *reader, size_t index, void *context)
+{
+    struct cmt_msgpack_decode_context *decode_context;
+
+    if (NULL == reader ||
+        NULL == context) {
+        return CMT_DECODE_MSGPACK_INVALID_ARGUMENT_ERROR;
+    }
+
+    decode_context = (struct cmt_msgpack_decode_context *) context;
+
+    return cmt_mpack_consume_double_tag(reader, &decode_context->bucket_list[index]);
+}
+
+static int unpack_meta_buckets(mpack_reader_t *reader, size_t index, void *context)
+{
+    struct cmt_msgpack_decode_context *decode_context;
+
+    if (NULL == reader ||
+        NULL == context) {
+        return CMT_DECODE_MSGPACK_INVALID_ARGUMENT_ERROR;
+    }
+
+    decode_context = (struct cmt_msgpack_decode_context *) context;
+
+    decode_context->bucket_count = cmt_mpack_peek_array_length(reader);
+
+    if (0 < decode_context->bucket_count) {
+        decode_context->bucket_list = calloc(decode_context->bucket_count,
+                                             sizeof(double));
+
+        if (NULL == decode_context->bucket_list) {
+            return CMT_DECODE_MSGPACK_ALLOCATION_ERROR;
+        }
+    }
+
+    return cmt_mpack_unpack_array(reader, unpack_meta_bucket, context);
+}
+
+static int initialize_histogram_bucket_list(struct cmt_histogram *histogram,
+                                            double *bucket_list,
+                                            size_t bucket_count)
+{
+    histogram->buckets = calloc(1, sizeof(struct cmt_histogram_buckets));
+
+    if (histogram->buckets == NULL) {
+        cmt_errno();
+
+        return CMT_DECODE_MSGPACK_ALLOCATION_ERROR;
+    }
+
+    histogram->buckets->count = bucket_count;
+    histogram->buckets->upper_bounds = bucket_list;
+
+    return CMT_DECODE_MSGPACK_SUCCESS;
+}
+
 static int unpack_basic_type_meta(mpack_reader_t *reader, size_t index, void *context)
 {
     int                                   result;
+    struct cmt_histogram                 *histogram;
     struct cmt_msgpack_decode_context    *decode_context;
     struct cmt_mpack_map_entry_callback_t callbacks[] = \
         {
@@ -580,6 +864,7 @@ static int unpack_basic_type_meta(mpack_reader_t *reader, size_t index, void *co
             {"label_dictionary", unpack_meta_label_dictionary},
             {"static_labels",    unpack_meta_static_labels},
             {"labels",           unpack_meta_labels},
+            {"buckets",          unpack_meta_buckets},
             {NULL,               NULL}
         };
 
@@ -594,6 +879,18 @@ static int unpack_basic_type_meta(mpack_reader_t *reader, size_t index, void *co
 
     if (CMT_DECODE_MSGPACK_SUCCESS == result) {
         decode_context->map->label_count = mk_list_size(&decode_context->map->label_keys);
+
+        if (decode_context->map->type == CMT_HISTOGRAM) {
+            histogram = (struct cmt_histogram *) decode_context->map->parent;
+
+            histogram->buckets =
+                cmt_histogram_buckets_create_size(decode_context->bucket_list,
+                                                  decode_context->bucket_count);
+
+            if (histogram->buckets == NULL) {
+                result = CMT_DECODE_MSGPACK_ALLOCATION_ERROR;
+            }
+        }
     }
 
     return result;
@@ -614,6 +911,7 @@ static int unpack_basic_type_values(mpack_reader_t *reader, size_t index, void *
 static int unpack_basic_type(mpack_reader_t *reader, struct cmt *cmt, struct cmt_map **map)
 {
     int                                   result;
+    struct cmt_histogram                 *histogram;
     struct cmt_msgpack_decode_context     decode_context;
     struct cmt_mpack_map_entry_callback_t callbacks[] = \
         {
@@ -626,6 +924,8 @@ static int unpack_basic_type(mpack_reader_t *reader, struct cmt *cmt, struct cmt
         NULL == map) {
         return CMT_DECODE_MSGPACK_INVALID_ARGUMENT_ERROR;
     }
+
+    memset(&decode_context, 0, sizeof(struct cmt_msgpack_decode_context));
 
     *map = cmt_map_create(0, NULL, 0, NULL, NULL);
 
@@ -656,14 +956,43 @@ static int unpack_basic_type(mpack_reader_t *reader, struct cmt *cmt, struct cmt
 
     result = cmt_mpack_unpack_map(reader, callbacks, (void *) &decode_context);
 
+    if ((*map)->parent == NULL) {
+        result = CMT_DECODE_MSGPACK_CORRUPT_INPUT_DATA_ERROR;
+    }
+
     if (CMT_DECODE_MSGPACK_SUCCESS != result) {
+        if ((*map)->opts != NULL) {
+            cmt_opts_exit((*map)->opts);
+
+            free((*map)->opts);
+        }
+
+        if ((*map)->parent != NULL) {
+            if ((*map)->type == CMT_HISTOGRAM) {
+                histogram = ((struct cmt_histogram *) (*map)->parent);
+
+                if (NULL != histogram->buckets) {
+                    if (NULL != histogram->buckets->upper_bounds) {
+                        free(histogram->buckets->upper_bounds);
+                    }
+
+                    free(histogram->buckets);
+                }
+            }
+
+            free((*map)->parent);
+        }
+
         cmt_map_destroy(*map);
-        free((*map)->opts);
 
         *map = NULL;
     }
 
     destroy_label_list(&decode_context.unique_label_list);
+
+    if (decode_context.bucket_list != NULL) {
+        free(decode_context.bucket_list);
+    }
 
     return result;
 }
@@ -678,12 +1007,13 @@ static int append_unpacked_counter_to_metrics_context(struct cmt *context,
         return CMT_DECODE_MSGPACK_INVALID_ARGUMENT_ERROR;
     }
 
-    counter = calloc(1, sizeof(struct cmt_counter));
+    counter = map->parent;
 
     if (NULL == counter) {
         return CMT_DECODE_MSGPACK_ALLOCATION_ERROR;
     }
 
+    counter->cmt = context;
     counter->map = map;
     map->parent = (void *) counter;
 
@@ -708,12 +1038,13 @@ static int append_unpacked_gauge_to_metrics_context(struct cmt *context,
         return CMT_DECODE_MSGPACK_INVALID_ARGUMENT_ERROR;
     }
 
-    gauge = calloc(1, sizeof(struct cmt_gauge));
+    gauge = map->parent;
 
     if (NULL == gauge) {
         return CMT_DECODE_MSGPACK_ALLOCATION_ERROR;
     }
 
+    gauge->cmt = context;
     gauge->map = map;
     map->parent = (void *) gauge;
 
@@ -738,11 +1069,12 @@ static int append_unpacked_untyped_to_metrics_context(struct cmt *context,
         return CMT_DECODE_MSGPACK_INVALID_ARGUMENT_ERROR;
     }
 
-    untyped = calloc(1, sizeof(struct cmt_untyped));
+    untyped = map->parent;
     if (NULL == untyped) {
         return CMT_DECODE_MSGPACK_ALLOCATION_ERROR;
     }
 
+    untyped->cmt = context;
     untyped->map = map;
     map->parent = (void *) untyped;
 
@@ -753,6 +1085,37 @@ static int append_unpacked_untyped_to_metrics_context(struct cmt *context,
     map->opts = &untyped->opts;
 
     mk_list_add(&untyped->_head, &context->untypeds);
+
+    return CMT_DECODE_MSGPACK_SUCCESS;
+}
+
+static int append_unpacked_histogram_to_metrics_context(
+    struct cmt *context,
+    struct cmt_map *map)
+{
+    struct cmt_histogram *histogram;
+
+    if (NULL == context ||
+        NULL == map     ) {
+        return CMT_DECODE_MSGPACK_INVALID_ARGUMENT_ERROR;
+    }
+
+    histogram = map->parent;
+    if (NULL == histogram) {
+        return CMT_DECODE_MSGPACK_ALLOCATION_ERROR;
+    }
+
+    histogram->cmt = context;
+    histogram->map = map;
+    map->parent = (void *) histogram;
+
+    memcpy(&histogram->opts, map->opts, sizeof(struct cmt_opts));
+
+    free(map->opts);
+
+    map->opts = &histogram->opts;
+
+    mk_list_add(&histogram->_head, &context->histograms);
 
     return CMT_DECODE_MSGPACK_SUCCESS;
 }
@@ -780,7 +1143,7 @@ static int unpack_basic_type_entry(mpack_reader_t *reader, size_t index, void *c
             result = append_unpacked_gauge_to_metrics_context(cmt, map);
         }
         else if (CMT_HISTOGRAM == map->type) {
-            // result = append_unpacked_histogram_to_metrics_context(cmt, map);
+            result = append_unpacked_histogram_to_metrics_context(cmt, map);
         }
         else if (CMT_UNTYPED == map->type) {
             result = append_unpacked_untyped_to_metrics_context(cmt, map);
@@ -839,7 +1202,8 @@ int cmt_decode_msgpack_create(struct cmt **out_cmt, char *in_buf, size_t in_size
 
     *offset += in_size - remainder;
 
-    result = mpack_reader_destroy(&reader);
+    mpack_reader_destroy(&reader);
+
 
     if (CMT_DECODE_MSGPACK_SUCCESS != result) {
         cmt_destroy(cmt);

--- a/src/cmt_encode_msgpack.c
+++ b/src/cmt_encode_msgpack.c
@@ -21,6 +21,7 @@
 #include <cmetrics/cmt_metric.h>
 #include <cmetrics/cmt_map.h>
 #include <cmetrics/cmt_sds.h>
+#include <cmetrics/cmt_histogram.h>
 #include <cmetrics/cmt_counter.h>
 #include <cmetrics/cmt_gauge.h>
 #include <cmetrics/cmt_untyped.h>
@@ -166,16 +167,26 @@ static void pack_header(mpack_writer_t *writer, struct cmt *cmt, struct cmt_map 
     struct cmt_opts      *opts;
     struct mk_list       *head;
     struct cmt_map_label *label;
+    struct cmt_histogram *histogram;
     ptrdiff_t             label_index;
     struct cmt_label     *static_label;
+    size_t                bucket_index;
+    size_t                meta_field_count;
 
     opts = map->opts;
+    meta_field_count = 6;
+
+    if (map->type == CMT_HISTOGRAM) {
+        histogram = (struct cmt_histogram *) map->parent;
+
+        meta_field_count++;
+    }
 
     mpack_start_map(writer, 2);
 
     /* 'meta' */
     mpack_write_cstr(writer, "meta");
-    mpack_start_map(writer, 6);
+    mpack_start_map(writer, meta_field_count);
 
     /* 'ver' */
     mpack_write_cstr(writer, "ver");
@@ -246,6 +257,20 @@ static void pack_header(mpack_writer_t *writer, struct cmt *cmt, struct cmt_map 
     }
     mpack_finish_array(writer);
 
+    if (map->type == CMT_HISTOGRAM) {
+        /* 'buckets' (histogram buckets) */
+        mpack_write_cstr(writer, "buckets");
+
+        mpack_start_array(writer, histogram->buckets->count);
+
+        for (bucket_index = 0 ;
+             bucket_index < histogram->buckets->count ;
+             bucket_index++) {
+            mpack_write_double(writer, histogram->buckets->upper_bounds[bucket_index]);
+        }
+        mpack_finish_array(writer);
+    }
+
     mpack_finish_map(writer); /* 'meta' */
 }
 
@@ -254,14 +279,22 @@ static int pack_metric(mpack_writer_t *writer, struct cmt_map *map, struct cmt_m
     int c_labels;
     int s;
     double val;
+    size_t index;
     struct mk_list *head;
     struct cmt_map_label *label;
+    struct cmt_histogram *histogram;
     ptrdiff_t label_index;
 
-    /* FYI: ONLY SUPPORTS COUNTER & GAUGE FOR NOW */
+    /* FYI: ONLY SUPPORTS COUNTER, GAUGE & HISTOGRAM FOR NOW */
+
     c_labels = mk_list_size(&metric->labels);
 
-    s = 2;
+    s = 3;
+
+    if (map->type == CMT_HISTOGRAM) {
+        s = 5;
+    }
+
     if (c_labels > 0) {
         s++;
     }
@@ -271,9 +304,32 @@ static int pack_metric(mpack_writer_t *writer, struct cmt_map *map, struct cmt_m
     mpack_write_cstr(writer, "ts");
     mpack_write_uint(writer, metric->timestamp);
 
-    mpack_write_cstr(writer, "value");
-    val = cmt_metric_get_value(metric);
-    mpack_write_double(writer, val);
+    if (map->type == CMT_HISTOGRAM) {
+        histogram = (struct cmt_histogram *) map->parent;
+
+        mpack_write_cstr(writer, "buckets");
+        mpack_start_array(writer, histogram->buckets->count);
+
+        for (index = 0 ;
+             index < histogram->buckets->count ;
+             index++) {
+            mpack_write_uint(writer, cmt_metric_hist_get_value(metric, index));
+        }
+
+        mpack_finish_array(writer);
+
+        mpack_write_cstr(writer, "sum");
+        mpack_write_double(writer, cmt_metric_hist_get_sum_value(metric));
+
+        mpack_write_cstr(writer, "count");
+        mpack_write_uint(writer, cmt_metric_hist_get_count_value(metric));
+    }
+    else {
+        mpack_write_cstr(writer, "value");
+        val = cmt_metric_get_value(metric);
+        mpack_write_double(writer, val);
+    }
+
 
     s = mk_list_size(&metric->labels);
     if (s > 0) {
@@ -289,6 +345,9 @@ static int pack_metric(mpack_writer_t *writer, struct cmt_map *map, struct cmt_m
         mpack_finish_array(writer);
     }
     mpack_finish_map(writer);
+
+    mpack_write_cstr(writer, "hash");
+    mpack_write_uint(writer, metric->hash);
 
     return 0;
 }
@@ -356,37 +415,51 @@ int cmt_encode_msgpack_create(struct cmt *cmt, char **out_buf, size_t *out_size)
     struct cmt_counter *counter;
     struct cmt_gauge *gauge;
     struct cmt_untyped *untyped;
+    struct cmt_histogram *histogram;
     size_t metric_count;
 
     /*
      * CMetrics data schema
-[
-     * {
-     *   'meta' => {
-     *                 'ver' => INTEGER
-     *                 'type' => INTEGER
-     *                           '0' = counter
-     *                           '1' = gauge
-     *                           '2' = histogram (WIP)
-     *                 'opts' => {
-     *                            'ns'   => ns
-     *                            'subsystem'   => subsystem
-     *                            'name'        => name
-     *                            'description' => description
-     *                           },
-     *                 'label_dictionary' => ['', ...],
-     *                 'static_labels' => [n, ...],
-     *                 'label_keys' => [n, ...]
-     *               },
-     *   'values' => [
-     *                 {
-     *                  'ts'   : nanosec timestamp,
-     *                  'value': float64 value
-     *                  'label_values': [n, ...]
-     *                 }
-     *               ]
-     * }
-]
+     *  [
+     *      {
+     *        'meta' => {
+     *                      'ver' => INTEGER
+     *                      'type' => INTEGER
+     *                                '0' = counter
+     *                                '1' = gauge
+     *                                '2' = histogram (WIP)
+     *                      'opts' => {
+     *                                 'ns'   => ns
+     *                                 'subsystem'   => subsystem
+     *                                 'name'        => name
+     *                                 'description' => description
+     *                                },
+     *                      'label_dictionary' => ['', ...],
+     *                      'static_labels' => [n, ...],
+     *                      'label_keys' => [n, ...],
+     *                      'buckets' => [n, ...]
+     *                    },
+     *        'values' => [
+     *                      {
+     *                       'ts'   : nanosec timestamp,
+     *                       'value': float64 value,
+     *                       'label_values': [n, ...],
+     *                       'buckets': [n, ...],
+     *                       'sum': float64 value,
+     *                       'count': uint64 value,
+     *                       'hash': uint64 value
+     *                      }
+     *                    ]
+     *      }
+     *  , ...]
+     *
+     *
+     * The following fields are metric type specific and are only
+     * included for histograms :
+     *      meta->buckets
+     *      values[n]->buckets
+     *      values[n]->count
+     *      values[n]->sum
      */
 
     mpack_writer_init_growable(&writer, &data, &size);
@@ -395,6 +468,7 @@ int cmt_encode_msgpack_create(struct cmt *cmt, char **out_buf, size_t *out_size)
     metric_count += mk_list_size(&cmt->counters);
     metric_count += mk_list_size(&cmt->gauges);
     metric_count += mk_list_size(&cmt->untypeds);
+    metric_count += mk_list_size(&cmt->histograms);
 
     /* We want an array to group all these metrics in a context */
     mpack_start_array(&writer, metric_count);
@@ -415,6 +489,12 @@ int cmt_encode_msgpack_create(struct cmt *cmt, char **out_buf, size_t *out_size)
     mk_list_foreach(head, &cmt->untypeds) {
         untyped = mk_list_entry(head, struct cmt_untyped, _head);
         pack_basic_type(&writer, cmt, untyped->map);
+    }
+
+    /* Histogram */
+    mk_list_foreach(head, &cmt->histograms) {
+        histogram = mk_list_entry(head, struct cmt_histogram, _head);
+        pack_basic_type(&writer, cmt, histogram->map);
     }
 
     if (mpack_writer_destroy(&writer) != mpack_ok) {

--- a/src/cmt_mpack_utils.c
+++ b/src/cmt_mpack_utils.c
@@ -161,7 +161,6 @@ int cmt_mpack_unpack_map(mpack_reader_t *reader,
 
         if (CMT_MPACK_SUCCESS == result) {
             callback_entry = callback_list;
-
             result = CMT_MPACK_UNEXPECTED_KEY_ERROR;
 
             while (CMT_MPACK_UNEXPECTED_KEY_ERROR == result &&
@@ -187,7 +186,7 @@ int cmt_mpack_unpack_map(mpack_reader_t *reader,
         }
     }
 
-    return CMT_MPACK_SUCCESS;
+    return result;
 }
 
 int cmt_mpack_unpack_array(mpack_reader_t *reader,
@@ -246,5 +245,23 @@ int cmt_mpack_unpack_array(mpack_reader_t *reader,
         }
     }
 
-    return 0;
+    return result;
+}
+
+int cmt_mpack_peek_array_length(mpack_reader_t *reader)
+{
+    mpack_tag_t tag;
+
+    tag = mpack_peek_tag(reader);
+
+    if (mpack_ok != mpack_reader_error(reader))
+    {
+        return 0;
+    }
+
+    if (mpack_type_array != mpack_tag_type(&tag)) {
+        return 0;
+    }
+
+    return mpack_tag_array_count(&tag);
 }

--- a/tests/encoding.c
+++ b/tests/encoding.c
@@ -16,10 +16,14 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
+#ifdef __GNUC__
+#define _GNU_SOURCE
+#endif
 
 #include <cmetrics/cmetrics.h>
 #include <cmetrics/cmt_gauge.h>
 #include <cmetrics/cmt_counter.h>
+#include <cmetrics/cmt_histogram.h>
 #include <cmetrics/cmt_encode_msgpack.h>
 #include <cmetrics/cmt_decode_msgpack.h>
 #include <cmetrics/cmt_encode_prometheus_remote_write.h>
@@ -68,6 +72,8 @@ static struct cmt *generate_encoder_test_data()
     struct cmt_counter *c1;
     struct cmt_counter *c2;
     struct cmt_counter *c3;
+    struct cmt_histogram *h1;
+    struct cmt_histogram_buckets *buckets;
 
     cmt = cmt_create();
 
@@ -110,6 +116,33 @@ static struct cmt *generate_encoder_test_data()
     c3 = cmt_counter_create(cmt, "kubernetes", "", "cpu", "CPU load",
                             2, (char *[]) {"hostname", "app"});
     cmt_counter_set(c3, ts, 10, 0, NULL);
+
+    /* Create buckets */
+    buckets = cmt_histogram_buckets_create(3, 0.05, 5.0, 10.0);
+    TEST_CHECK(buckets != NULL);
+
+    /* Create a gauge metric type */
+    h1 = cmt_histogram_create(cmt,
+                              "k8s", "network", "load", "Network load",
+                              buckets,
+                              1, (char *[]) {"my_label"});
+    TEST_CHECK(h1 != NULL);
+
+    ts = 0;
+
+    /* no labels */
+    cmt_histogram_observe(h1, ts, 0.001, 0, NULL);
+    cmt_histogram_observe(h1, ts, 0.020, 0, NULL);
+    cmt_histogram_observe(h1, ts, 5.0, 0, NULL);
+    cmt_histogram_observe(h1, ts, 8.0, 0, NULL);
+    cmt_histogram_observe(h1, ts, 1000, 0, NULL);
+
+    /* defined labels: add a custom label value */
+    cmt_histogram_observe(h1, ts, 0.001, 1, (char *[]) {"my_val"});
+    cmt_histogram_observe(h1, ts, 0.020, 1, (char *[]) {"my_val"});
+    cmt_histogram_observe(h1, ts, 5.0, 1, (char *[]) {"my_val"});
+    cmt_histogram_observe(h1, ts, 8.0, 1, (char *[]) {"my_val"});
+    cmt_histogram_observe(h1, ts, 1000, 1, (char *[]) {"my_val"});;
 
     return cmt;
 }
@@ -159,6 +192,65 @@ void test_cmt_to_msgpack()
     cmt_decode_msgpack_destroy(cmt2);
     cmt_encode_msgpack_destroy(mp1_buf);
     cmt_encode_msgpack_destroy(mp2_buf);
+}
+
+/*
+ * Encode a context, corrupt the last metric in the msgpack packet
+ * and invoke the decoder to verify if there are any leaks.
+ *
+ * CMT -> MSGPACK -> CMT
+ *
+ * Note: this function is meant to be executed in linux while using
+ * valgrind
+ */
+
+void test_cmt_to_msgpack_cleanup_on_error()
+{
+#ifdef __linux__
+    int ret;
+    size_t offset = 0;
+    char *mp1_buf = NULL;
+    size_t mp1_size = 0;
+    char *mp2_buf = NULL;
+    size_t mp2_size = 0;
+    struct cmt *cmt1 = NULL;
+    struct cmt *cmt2 = NULL;
+    char *key_buffer = NULL;
+    char *key_haystack = NULL;
+
+    cmt_initialize();
+
+    /* Generate context with data */
+    cmt1 = generate_encoder_test_data();
+    TEST_CHECK(cmt1 != NULL);
+
+    /* CMT1 -> Msgpack */
+    ret = cmt_encode_msgpack_create(cmt1, &mp1_buf, &mp1_size);
+    TEST_CHECK(ret == 0);
+
+    key_haystack = &mp1_buf[mp1_size - 32];
+    key_buffer = memmem(key_haystack, 32, "hash", 4);
+
+    TEST_CHECK(key_buffer != NULL);
+
+    /* This turns the last 'hash' entry into 'hasq' which causes
+     * the map consumer in the decoder to detect an unprocessed entry
+     * and abort in `unpack_metric` which means a lot of allocations
+     * have been made including but not limited to temporary
+     * histogram bucket arrays and completely decoded histograms
+     */
+    key_buffer[3] = 'q';
+
+    /* Msgpack -> CMT2 */
+    ret = cmt_decode_msgpack_create(&cmt2, mp1_buf, mp1_size, &offset);
+
+    cmt_destroy(cmt1);
+    cmt_encode_msgpack_destroy(mp1_buf);
+
+    TEST_CHECK(ret != 0);
+    TEST_CHECK(cmt2 == NULL);
+
+#endif
 }
 
 /*
@@ -666,6 +758,7 @@ void test_influx()
 }
 
 TEST_LIST = {
+    {"cmt_msgpack_cleanup_on_error",   test_cmt_to_msgpack_cleanup_on_error},
     {"cmt_msgpack_partial_processing", test_cmt_msgpack_partial_processing},
     {"prometheus_remote_write",        test_prometheus_remote_write},
     {"cmt_msgpack_stability",          test_cmt_to_msgpack_stability},


### PR DESCRIPTION
This PR adds histogram support to the msgpack encoder/decoder pair, both `cmt_msgpack` and `cmt_msgpack_cleanup_on_error` are can be executed under valgrind to verify the encoder/decoder pair do not leak.