### PR TITLE
decode: prometheus: Add Summary support

### DIFF
--- a/include/cmetrics/cmt_decode_prometheus.h
+++ b/include/cmetrics/cmt_decode_prometheus.h
@@ -29,7 +29,6 @@
 #define CMT_DECODE_PROMETHEUS_SUCCESS                     0
 #define CMT_DECODE_PROMETHEUS_SYNTAX_ERROR                1
 #define CMT_DECODE_PROMETHEUS_ALLOCATION_ERROR           10
-#define CMT_DECODE_PROMETHEUS_PARSE_UNSUPPORTED_TYPE     20
 #define CMT_DECODE_PROMETHEUS_MAX_LABEL_COUNT_EXCEEDED   30
 #define CMT_DECODE_PROMETHEUS_CMT_SET_ERROR              40
 #define CMT_DECODE_PROMETHEUS_CMT_CREATE_ERROR           50
@@ -73,7 +72,6 @@ struct cmt_decode_prometheus_parse_opts {
     uint64_t default_timestamp;
     char *errbuf;
     size_t errbuf_size;
-    bool skip_unsupported_type;
 };
 
 struct cmt_decode_prometheus_context {


### PR DESCRIPTION
Adds summary support to prometheus decoder.

Note: Since cmetrics API doesn't allow setting "quantile" label values, they are ignored when parsing (as shown in the added test).

Also removed the option to skip unsupported type, since we now support all types of metrics.