### PR TITLE
build on aarch64.

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -12,12 +12,11 @@ jobs:
     name: Build sources on amd64 for ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:
-      max-parallel: 48
       fail-fast: false
       matrix:
         os: [windows-latest, windows-2019]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Build on ${{ matrix.os }} with vs-2019
         run: |
           .\scripts\win_build.bat
@@ -41,24 +40,51 @@ jobs:
           rpm -ivh epel-release-latest-7.noarch.rpm && \
           yum install -y cmake3
 
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Run compilation
         run: |
           cmake3 -DCMT_TESTS=on -DCMT_DEV=on .
           make
 
-  build-unix:
+  build-unix-arm64:
+    name: Build sources on arm64 for ${{ matrix.os }} - ${{ matrix.compiler }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest]
+        compiler: [ gcc, clang ]
+    steps:
+      - uses: actions/checkout@v3
+      - name: Build on ${{ matrix.os }} with ${{ matrix.compiler }}
+        uses: uraimo/run-on-arch-action@v2.1.1
+        with:
+          arch: aarch64
+          distro: ubuntu20.04
+          run: |
+            apt-get update && \
+            apt-get install -y --no-install-recommends \
+            build-essential \
+            cmake \
+            file \
+            make 
+            export CC=${{ env.compiler }}
+            cmake -DCMT_TESTS=On .
+            make all
+            CTEST_OUTPUT_ON_FAILURE=1 make test
+        env:
+          CC: ${{ matrix.compiler }}
+  build-unix-amd64:
     name: Build sources on amd64 for ${{ matrix.os }} - ${{ matrix.compiler }}
     runs-on: ${{ matrix.os }}
     strategy:
-      max-parallel: 48
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest]
         compiler: [ gcc, clang ]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Build on ${{ matrix.os }} with ${{ matrix.compiler }}
         run: |
           echo "CC = $CC, CXX = $CXX"

--- a/.github/workflows/packages.yaml
+++ b/.github/workflows/packages.yaml
@@ -10,8 +10,40 @@ on:
   workflow_dispatch:
 
 jobs:
-  build-distro-packages:
-    name: build packages
+  build-distro-packages-arm64:
+    runs-on: ubuntu-latest
+    name: build arm64 packages
+    strategy:
+      fail-fast: true
+      matrix:
+        format: [ rpm, deb ]
+    steps:
+      - uses: actions/checkout@v2
+      - uses: uraimo/run-on-arch-action@v2.1.1
+        name: Build the ${{matrix.format}} packages
+        with:
+          arch: aarch64
+          distro: ubuntu20.04
+          run: |
+            apt-get update && \
+            apt-get install -y --no-install-recommends \
+            build-essential \
+            cmake \
+            file \
+            rpm \
+            make 
+            cmake .
+            echo ${{ matrix.format }} | awk '{print toupper($0)}' | xargs -I{} cpack -G {}
+
+      - name: Store the master package artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: ${{ matrix.format }}
+          path: |
+            ./*.${{matrix.format}}
+
+  build-distro-packages-amd64:
+    name: build amd64 packages
     strategy:
       fail-fast: true
       matrix:
@@ -34,7 +66,9 @@ jobs:
 
   release:
     name: Create release and upload packages
-    needs: build-distro-packages
+    needs:
+      - build-distro-packages-amd64
+      - build-distro-packages-arm64
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/packages.yaml
+++ b/.github/workflows/packages.yaml
@@ -38,7 +38,7 @@ jobs:
       - name: Store the master package artifacts
         uses: actions/upload-artifact@v2
         with:
-          name: ${{ matrix.format }}
+          name: ${{ matrix.format }}-arm64
           path: |
             ./*.${{matrix.format}}
 
@@ -60,7 +60,7 @@ jobs:
       - name: Store the master package artifacts
         uses: actions/upload-artifact@v2
         with:
-          name: ${{ matrix.format }}
+          name: ${{ matrix.format }}-amd64
           path: |
             ./*.${{matrix.format}}
 


### PR DESCRIPTION
- build using run-on-arch action, this has to be switched
into a base build container that does aarch64 binary emulation or its own
runner.
- store the aarch64 artifacts

Signed-off-by: Jorge Niedbalski <j@calyptia.com>