### PR TITLE
encoding: opentelemetry: added histogram and summary support

### DIFF
--- a/src/cmt_encode_opentelemetry.c
+++ b/src/cmt_encode_opentelemetry.c
@@ -20,9 +20,11 @@
 #include <cmetrics/cmt_metric.h>
 #include <cmetrics/cmt_map.h>
 #include <cmetrics/cmt_sds.h>
-#include <cmetrics/cmt_counter.h>
 #include <cmetrics/cmt_gauge.h>
+#include <cmetrics/cmt_counter.h>
 #include <cmetrics/cmt_untyped.h>
+#include <cmetrics/cmt_summary.h>
+#include <cmetrics/cmt_histogram.h>
 #include <cmetrics/cmt_hash.h> 
 #include <cmetrics/cmt_encode_opentelemetry.h>
 
@@ -32,6 +34,20 @@ static int is_string_releaseable(char *address);
 static int is_metric_empty(struct cmt_map *map);
 
 static size_t get_metric_count(struct cmt *cmt);
+
+static Opentelemetry__Proto__Metrics__V1__SummaryDataPoint__ValueAtQuantile *
+    initialize_summary_value_at_quantile(
+    double quantile, double value);
+
+static void destroy_summary_value_at_quantile(
+    Opentelemetry__Proto__Metrics__V1__SummaryDataPoint__ValueAtQuantile *value);
+
+static Opentelemetry__Proto__Metrics__V1__SummaryDataPoint__ValueAtQuantile **
+    initialize_summary_value_at_quantile_list(
+    size_t element_count);
+
+static void destroy_summary_value_at_quantile_list(
+    Opentelemetry__Proto__Metrics__V1__SummaryDataPoint__ValueAtQuantile **list);
 
 static void destroy_export_metrics_service_request(
     Opentelemetry__Proto__Collector__Metrics__V1__ExportMetricsServiceRequest *request);
@@ -111,27 +127,99 @@ static Opentelemetry__Proto__Common__V1__KeyValue **
     initialize_attribute_list(
     size_t element_count);
 
-static void destroy_data_point(
+static void destroy_numerical_data_point(
     Opentelemetry__Proto__Metrics__V1__NumberDataPoint *data_point);
 
+static void destroy_summary_data_point(
+    Opentelemetry__Proto__Metrics__V1__SummaryDataPoint *data_point);
+
+static void destroy_histogram_data_point(
+    Opentelemetry__Proto__Metrics__V1__HistogramDataPoint *data_point);
+
+static void destroy_data_point(
+    void *data_point,
+    int data_point_type);
+
+static void destroy_numerical_data_point_list(
+    Opentelemetry__Proto__Metrics__V1__NumberDataPoint **data_point_list);
+
+static void destroy_summary_data_point_list(
+    Opentelemetry__Proto__Metrics__V1__SummaryDataPoint **data_point_list);
+
+static void destroy_histogram_data_point_list(
+    Opentelemetry__Proto__Metrics__V1__HistogramDataPoint **data_point_list);
+
+static void destroy_data_point_list(
+    void **data_point_list,
+    int data_point_type);
+
 static Opentelemetry__Proto__Metrics__V1__NumberDataPoint *
-    initialize_double_data_point(
+    initialize_numerical_data_point(
     uint64_t start_time,
     uint64_t timestamp,
     double value,
     Opentelemetry__Proto__Common__V1__KeyValue **attribute_list,
     size_t attribute_count);
 
-static int append_attribute_to_data_point(
+static Opentelemetry__Proto__Metrics__V1__SummaryDataPoint *
+    initialize_summary_data_point(
+    uint64_t start_time,
+    uint64_t timestamp,
+    uint64_t count,
+    double sum,
+    size_t quantile_count,
+    double *quantile_list,
+    size_t value_count,
+    uint64_t *value_list,
+    Opentelemetry__Proto__Common__V1__KeyValue **attribute_list,
+    size_t attribute_count);
+
+static Opentelemetry__Proto__Metrics__V1__HistogramDataPoint *
+    initialize_histogram_data_point(
+    uint64_t start_time,
+    uint64_t timestamp,
+    uint64_t count,
+    double sum,
+    size_t bucket_count,
+    uint64_t *bucket_list,
+    size_t boundary_count,
+    double *boundary_list,
+    Opentelemetry__Proto__Common__V1__KeyValue **attribute_list,
+    size_t attribute_count);
+
+static int append_attribute_to_numerical_data_point(
     Opentelemetry__Proto__Metrics__V1__NumberDataPoint *data_point,
     Opentelemetry__Proto__Common__V1__KeyValue *attribute,
     size_t attribute_slot_hint);
 
-static void destroy_data_point_list(
-    Opentelemetry__Proto__Metrics__V1__NumberDataPoint **data_point_list);
+static int append_attribute_to_summary_data_point(
+    Opentelemetry__Proto__Metrics__V1__SummaryDataPoint *data_point,
+    Opentelemetry__Proto__Common__V1__KeyValue *attribute,
+    size_t attribute_slot_hint);
+
+static int append_attribute_to_histogram_data_point(
+    Opentelemetry__Proto__Metrics__V1__HistogramDataPoint *data_point,
+    Opentelemetry__Proto__Common__V1__KeyValue *attribute,
+    size_t attribute_slot_hint);
+
+static int append_attribute_to_data_point(
+    void *data_point,
+    int data_point_type,
+    Opentelemetry__Proto__Common__V1__KeyValue *attribute,
+    size_t attribute_slot_hint);
+
+static int append_attribute_to_data_point(
+    void *data_point,
+    int data_point_type,
+    Opentelemetry__Proto__Common__V1__KeyValue *attribute,
+    size_t attribute_slot_hint);
 
 static Opentelemetry__Proto__Metrics__V1__NumberDataPoint **
-    initialize_data_point_list(
+    initialize_numerical_data_point_list(
+    size_t element_count);
+
+static Opentelemetry__Proto__Metrics__V1__HistogramDataPoint **
+    initialize_histogram_data_point_list(
     size_t element_count);
 
 static void destroy_metric(
@@ -148,7 +236,7 @@ static Opentelemetry__Proto__Metrics__V1__Metric *
 
 static int append_data_point_to_metric(
     Opentelemetry__Proto__Metrics__V1__Metric *metric,
-    Opentelemetry__Proto__Metrics__V1__NumberDataPoint *data_point,
+    void *data_point,
     size_t data_point_slot_hint);
 
 static void destroy_metric_list(
@@ -190,11 +278,13 @@ static int is_metric_empty(struct cmt_map *map)
 
 static size_t get_metric_count(struct cmt *cmt)
 {
-    size_t              metric_count;
-    struct cmt_untyped *untyped;
-    struct cmt_counter *counter;
-    struct cmt_gauge   *gauge;
-    struct mk_list     *head;
+    size_t                metric_count;
+    struct cmt_histogram *histogram;
+    struct cmt_summary   *summary;
+    struct cmt_untyped   *untyped;
+    struct cmt_counter   *counter;
+    struct cmt_gauge     *gauge;
+    struct mk_list       *head;
 
     metric_count = 0;
 
@@ -214,6 +304,18 @@ static size_t get_metric_count(struct cmt *cmt)
         untyped = mk_list_entry(head, struct cmt_untyped, _head);
 
         metric_count += !is_metric_empty(untyped->map);
+    }
+
+    mk_list_foreach(head, &cmt->summaries) {
+        summary = mk_list_entry(head, struct cmt_summary, _head);
+
+        metric_count += !is_metric_empty(summary->map);
+    }
+
+    mk_list_foreach(head, &cmt->histograms) {
+        histogram = mk_list_entry(head, struct cmt_histogram, _head);
+
+        metric_count += !is_metric_empty(histogram->map);
     }
 
     return metric_count;
@@ -698,7 +800,7 @@ static Opentelemetry__Proto__Common__V1__KeyValue **
     return attribute_list;
 }
 
-static void destroy_data_point(
+static void destroy_numerical_data_point(
     Opentelemetry__Proto__Metrics__V1__NumberDataPoint *data_point)
 {
     if (data_point != NULL) {
@@ -708,8 +810,123 @@ static void destroy_data_point(
     }
 }
 
+static void destroy_summary_data_point(
+    Opentelemetry__Proto__Metrics__V1__SummaryDataPoint *data_point)
+{
+    if (data_point != NULL) {
+        destroy_attribute_list(data_point->attributes);
+
+        if (data_point->quantile_values != NULL) {
+            destroy_summary_value_at_quantile_list(data_point->quantile_values);
+        }
+
+        free(data_point);
+    }
+}
+
+static void destroy_histogram_data_point(
+    Opentelemetry__Proto__Metrics__V1__HistogramDataPoint *data_point)
+{
+    if (data_point != NULL) {
+        destroy_attribute_list(data_point->attributes);
+
+        if (data_point->bucket_counts != NULL) {
+            free(data_point->bucket_counts);
+        }
+
+        if (data_point->explicit_bounds != NULL) {
+            free(data_point->explicit_bounds);
+        }
+
+        free(data_point);
+    }
+}
+
+static void destroy_data_point(
+    void *data_point,
+    int data_point_type)
+{
+    switch (data_point_type) {
+        case CMT_COUNTER:
+        case CMT_GAUGE:
+        case CMT_UNTYPED:
+            return destroy_numerical_data_point(data_point);
+        case CMT_HISTOGRAM:
+            return destroy_histogram_data_point(data_point);
+    }
+}
+
+static void destroy_numerical_data_point_list(
+    Opentelemetry__Proto__Metrics__V1__NumberDataPoint **data_point_list)
+{
+    size_t element_index;
+
+    if (data_point_list != NULL) {
+        for (element_index = 0 ;
+             data_point_list[element_index] != NULL ;
+             element_index++) {
+            destroy_numerical_data_point(data_point_list[element_index]);
+
+            data_point_list[element_index] = NULL;
+        }
+
+        free(data_point_list);
+    }
+}
+
+static void destroy_summary_data_point_list(
+    Opentelemetry__Proto__Metrics__V1__SummaryDataPoint **data_point_list)
+{
+    size_t element_index;
+
+    if (data_point_list != NULL) {
+        for (element_index = 0 ;
+             data_point_list[element_index] != NULL ;
+             element_index++) {
+            destroy_summary_data_point(data_point_list[element_index]);
+
+            data_point_list[element_index] = NULL;
+        }
+
+        free(data_point_list);
+    }
+}
+
+
+static void destroy_histogram_data_point_list(
+    Opentelemetry__Proto__Metrics__V1__HistogramDataPoint **data_point_list)
+{
+    size_t element_index;
+
+    if (data_point_list != NULL) {
+        for (element_index = 0 ;
+             data_point_list[element_index] != NULL ;
+             element_index++) {
+            destroy_histogram_data_point(data_point_list[element_index]);
+
+            data_point_list[element_index] = NULL;
+        }
+
+        free(data_point_list);
+    }
+}
+
+static void destroy_data_point_list(
+    void **data_point_list,
+    int data_point_type)
+{
+    switch (data_point_type) {
+        case CMT_COUNTER:
+        case CMT_GAUGE:
+        case CMT_UNTYPED:
+            return destroy_numerical_data_point_list((Opentelemetry__Proto__Metrics__V1__NumberDataPoint **) data_point_list);
+        case CMT_HISTOGRAM:
+            return destroy_histogram_data_point_list((Opentelemetry__Proto__Metrics__V1__HistogramDataPoint **) data_point_list);
+    }
+}
+
 static Opentelemetry__Proto__Metrics__V1__NumberDataPoint *
-    initialize_double_data_point(
+    initialize_numerical_data_point(
     uint64_t start_time,
     uint64_t timestamp,
     double value,
@@ -737,7 +954,209 @@ static Opentelemetry__Proto__Metrics__V1__NumberDataPoint *
     return data_point;
 }
 
-static int append_attribute_to_data_point(
+static Opentelemetry__Proto__Metrics__V1__SummaryDataPoint__ValueAtQuantile *
+    initialize_summary_value_at_quantile(
+    double quantile, double value)
+{
+    Opentelemetry__Proto__Metrics__V1__SummaryDataPoint__ValueAtQuantile *instance;
+
+    instance = calloc(1, sizeof(Opentelemetry__Proto__Metrics__V1__SummaryDataPoint__ValueAtQuantile));
+
+    if (instance != NULL) {
+        opentelemetry__proto__metrics__v1__summary_data_point__value_at_quantile__init(instance);
+
+        instance->quantile = quantile;
+        instance->value = value;
+    }
+
+    return instance;
+}
+
+static void destroy_summary_value_at_quantile(
+    Opentelemetry__Proto__Metrics__V1__SummaryDataPoint__ValueAtQuantile *value)
+{
+    if (value != NULL) {
+        free(value);
+    }
+}
+
+static Opentelemetry__Proto__Metrics__V1__SummaryDataPoint__ValueAtQuantile **
+    initialize_summary_value_at_quantile_list(
+    size_t element_count)
+{
+    Opentelemetry__Proto__Metrics__V1__SummaryDataPoint__ValueAtQuantile **list;
+
+    list = calloc(element_count + 1,
+                  sizeof(Opentelemetry__Proto__Metrics__V1__SummaryDataPoint__ValueAtQuantile *));
+
+    return list;
+}
+
+static void destroy_summary_value_at_quantile_list(
+    Opentelemetry__Proto__Metrics__V1__SummaryDataPoint__ValueAtQuantile **list)
+{
+    size_t index;
+
+    if (list != NULL) {
+        for (index = 0 ;
+             list[index] != NULL ;
+             index++) {
+            destroy_summary_value_at_quantile(list[index]);
+
+            list[index] = NULL;
+        }
+
+        free(list);
+    }
+}
+
+
+
+static Opentelemetry__Proto__Metrics__V1__SummaryDataPoint *
+    initialize_summary_data_point(
+    uint64_t start_time,
+    uint64_t timestamp,
+    uint64_t count,
+    double sum,
+    size_t quantile_count,
+    double *quantile_list,
+    size_t value_count,
+    uint64_t *value_list,
+    Opentelemetry__Proto__Common__V1__KeyValue **attribute_list,
+    size_t attribute_count)
+{
+    Opentelemetry__Proto__Metrics__V1__SummaryDataPoint  *data_point;
+    size_t                                                index;
+
+    data_point = calloc(1,
+                        sizeof(Opentelemetry__Proto__Metrics__V1__SummaryDataPoint));
+
+    if (data_point == NULL) {
+        return NULL;
+    }
+
+    opentelemetry__proto__metrics__v1__summary_data_point__init(data_point);
+
+    data_point->start_time_unix_nano = start_time;
+    data_point->time_unix_nano = timestamp;
+
+    data_point->count = count;
+    data_point->sum = sum;
+    data_point->n_quantile_values = quantile_count;
+
+    data_point->quantile_values = initialize_summary_value_at_quantile_list(quantile_count);
+
+    if (data_point->quantile_values == NULL) {
+        cmt_errno();
+
+        free(data_point);
+
+        return NULL;
+    }
+
+    if (quantile_count > 0) {
+        if (value_list != NULL) {
+            for (index = 0 ; index < quantile_count ; index++) {
+                data_point->quantile_values[index] =
+                    initialize_summary_value_at_quantile(quantile_list[index],
+                                                         cmt_math_uint64_to_d64(value_list[index]));
+
+                if (data_point->quantile_values[index] == NULL) {
+                    cmt_errno();
+
+                    destroy_summary_value_at_quantile_list(data_point->quantile_values);
+
+                    free(data_point);
+
+                    return NULL;
+                }
+            }
+        }
+    }
+
+    data_point->attributes = attribute_list;
+    data_point->n_attributes = attribute_count;
+
+    return data_point;
+}
+
+static Opentelemetry__Proto__Metrics__V1__HistogramDataPoint *
+    initialize_histogram_data_point(
+    uint64_t start_time,
+    uint64_t timestamp,
+    uint64_t count,
+    double sum,
+    size_t bucket_count,
+    uint64_t *bucket_list,
+    size_t boundary_count,
+    double *boundary_list,
+    Opentelemetry__Proto__Common__V1__KeyValue **attribute_list,
+    size_t attribute_count)
+{
+    Opentelemetry__Proto__Metrics__V1__HistogramDataPoint  *data_point;
+    size_t                                                  index;
+
+    data_point = calloc(1,
+                        sizeof(Opentelemetry__Proto__Metrics__V1__HistogramDataPoint));
+
+    if (data_point == NULL) {
+        return NULL;
+    }
+
+    opentelemetry__proto__metrics__v1__histogram_data_point__init(data_point);
+
+    data_point->start_time_unix_nano = start_time;
+    data_point->time_unix_nano = timestamp;
+
+    data_point->count = count;
+    data_point->sum = sum;
+    data_point->n_bucket_counts = bucket_count;
+
+    if (bucket_count > 0) {
+        data_point->bucket_counts = calloc(bucket_count, sizeof(uint64_t));
+
+        if (data_point->bucket_counts == NULL) {
+            cmt_errno();
+
+            free(data_point);
+
+            return NULL;
+        }
+
+        if (bucket_list != NULL) {
+            for (index = 0 ; index < bucket_count ; index++) {
+                data_point->bucket_counts[index] = bucket_list[index];
+            }
+        }
+    }
+
+    data_point->n_explicit_bounds = boundary_count;
+
+    if (boundary_count > 0) {
+        data_point->explicit_bounds = calloc(boundary_count, sizeof(uint64_t));
+
+        if (data_point->explicit_bounds == NULL) {
+            cmt_errno();
+
+            free(data_point);
+
+            return NULL;
+        }
+
+        if (boundary_list != NULL) {
+            for (index = 0 ; index < boundary_count ; index++) {
+                data_point->explicit_bounds[index] = boundary_list[index];
+            }
+        }
+    }
+
+    data_point->attributes = attribute_list;
+    data_point->n_attributes = attribute_count;
+
+    return data_point;
+}
+
+static int append_attribute_to_numerical_data_point(
     Opentelemetry__Proto__Metrics__V1__NumberDataPoint *data_point,
     Opentelemetry__Proto__Common__V1__KeyValue *attribute,
     size_t attribute_slot_hint)
@@ -757,32 +1176,112 @@ static int append_attribute_to_data_point(
     return -1;
 }
 
-static void destroy_data_point_list(
-    Opentelemetry__Proto__Metrics__V1__NumberDataPoint **data_point_list)
+static int append_attribute_to_summary_data_point(
+    Opentelemetry__Proto__Metrics__V1__SummaryDataPoint *data_point,
+    Opentelemetry__Proto__Common__V1__KeyValue *attribute,
+    size_t attribute_slot_hint)
 {
-    size_t element_index;
+    size_t attribute_slot_index;
 
-    if (data_point_list != NULL) {
-        for (element_index = 0 ;
-             data_point_list[element_index] != NULL ;
-             element_index++) {
-            destroy_data_point(data_point_list[element_index]);
+    for (attribute_slot_index = attribute_slot_hint ;
+         attribute_slot_index < data_point->n_attributes;
+         attribute_slot_index++) {
+        if (data_point->attributes[attribute_slot_index] == NULL) {
+            data_point->attributes[attribute_slot_index] = attribute;
 
-            data_point_list[element_index] = NULL;
+            return 0;
         }
-
-        free(data_point_list);
     }
+
+    return -1;
+}
+
+static int append_attribute_to_histogram_data_point(
+    Opentelemetry__Proto__Metrics__V1__HistogramDataPoint *data_point,
+    Opentelemetry__Proto__Common__V1__KeyValue *attribute,
+    size_t attribute_slot_hint)
+{
+    size_t attribute_slot_index;
+
+    for (attribute_slot_index = attribute_slot_hint ;
+         attribute_slot_index < data_point->n_attributes;
+         attribute_slot_index++) {
+        if (data_point->attributes[attribute_slot_index] == NULL) {
+            data_point->attributes[attribute_slot_index] = attribute;
+
+            return 0;
+        }
+    }
+
+    return -1;
+}
+
+static int append_attribute_to_data_point(
+    void *data_point,
+    int data_point_type,
+    Opentelemetry__Proto__Common__V1__KeyValue *attribute,
+    size_t attribute_slot_hint)
+{
+    switch (data_point_type) {
+        case CMT_COUNTER:
+        case CMT_GAUGE:
+        case CMT_UNTYPED:
+            return append_attribute_to_numerical_data_point(data_point,
+                                                            attribute,
+                                                            attribute_slot_hint);
+        case CMT_SUMMARY:
+            return append_attribute_to_summary_data_point(data_point,
+                                                          attribute,
+                                                          attribute_slot_hint);
+        case CMT_HISTOGRAM:
+            return append_attribute_to_histogram_data_point(data_point,
+                                                                attribute,
+                                                                attribute_slot_hint);
+    }
+
+    return -1;
 }
 
 static Opentelemetry__Proto__Metrics__V1__NumberDataPoint **
-    initialize_data_point_list(
+    initialize_numerical_data_point_list(
     size_t element_count)
 {
     Opentelemetry__Proto__Metrics__V1__NumberDataPoint **data_point_list;
 
     data_point_list = calloc(element_count + 1,
                          sizeof(Opentelemetry__Proto__Metrics__V1__NumberDataPoint *));
+
+    if (data_point_list == NULL) {
+        return NULL;
+    }
+
+    return data_point_list;
+}
+
+static Opentelemetry__Proto__Metrics__V1__SummaryDataPoint **
+    initialize_summary_data_point_list(
+    size_t element_count)
+{
+    Opentelemetry__Proto__Metrics__V1__SummaryDataPoint **data_point_list;
+
+    data_point_list = calloc(element_count + 1,
+                         sizeof(Opentelemetry__Proto__Metrics__V1__SummaryDataPoint *));
+
+    if (data_point_list == NULL) {
+        return NULL;
+    }
+
+    return data_point_list;
+}
+
+static Opentelemetry__Proto__Metrics__V1__HistogramDataPoint **
+    initialize_histogram_data_point_list(
+    size_t element_count)
+{
+    Opentelemetry__Proto__Metrics__V1__HistogramDataPoint **data_point_list;
+
+    data_point_list = calloc(element_count + 1,
+                         sizeof(Opentelemetry__Proto__Metrics__V1__HistogramDataPoint *));
 
     if (data_point_list == NULL) {
         return NULL;
@@ -811,10 +1310,24 @@ static void destroy_metric(
         }
 
         if (metric->data_case == OPENTELEMETRY__PROTO__METRICS__V1__METRIC__DATA_SUM) {
-            destroy_data_point_list(metric->sum->data_points);
+            destroy_numerical_data_point_list(metric->sum->data_points);
+
+            free(metric->sum);
         }
         else if (metric->data_case == OPENTELEMETRY__PROTO__METRICS__V1__METRIC__DATA_GAUGE) {
-            destroy_data_point_list(metric->gauge->data_points);
+            destroy_numerical_data_point_list(metric->gauge->data_points);
+
+            free(metric->gauge);
+        }
+        else if (metric->data_case == OPENTELEMETRY__PROTO__METRICS__V1__METRIC__DATA_SUMMARY) {
+            destroy_summary_data_point_list(metric->summary->data_points);
+
+            free(metric->histogram);
+        }
+        else if (metric->data_case == OPENTELEMETRY__PROTO__METRICS__V1__METRIC__DATA_HISTOGRAM) {
+            destroy_histogram_data_point_list(metric->histogram->data_points);
+
+            free(metric->histogram);
         }
 
         free(metric);
@@ -881,7 +1394,7 @@ static Opentelemetry__Proto__Metrics__V1__Metric *
         opentelemetry__proto__metrics__v1__sum__init(metric->sum);
 
         metric->data_case = OPENTELEMETRY__PROTO__METRICS__V1__METRIC__DATA_SUM;
-        metric->sum->data_points = initialize_data_point_list(data_point_count);
+        metric->sum->data_points = initialize_numerical_data_point_list(data_point_count);
 
         if (metric->sum->data_points == NULL) {
             destroy_metric(metric);
@@ -906,7 +1419,7 @@ static Opentelemetry__Proto__Metrics__V1__Metric *
         opentelemetry__proto__metrics__v1__sum__init(metric->sum);
 
         metric->data_case = OPENTELEMETRY__PROTO__METRICS__V1__METRIC__DATA_SUM;
-        metric->sum->data_points = initialize_data_point_list(data_point_count);
+        metric->sum->data_points = initialize_numerical_data_point_list(data_point_count);
 
         if (metric->sum->data_points == NULL) {
             destroy_metric(metric);
@@ -928,7 +1441,7 @@ static Opentelemetry__Proto__Metrics__V1__Metric *
         opentelemetry__proto__metrics__v1__gauge__init(metric->gauge);
 
         metric->data_case = OPENTELEMETRY__PROTO__METRICS__V1__METRIC__DATA_GAUGE;
-        metric->gauge->data_points = initialize_data_point_list(data_point_count);
+        metric->gauge->data_points = initialize_numerical_data_point_list(data_point_count);
 
         if (metric->gauge->data_points == NULL) {
             destroy_metric(metric);
@@ -938,30 +1451,83 @@ static Opentelemetry__Proto__Metrics__V1__Metric *
 
         metric->gauge->n_data_points = data_point_count;
     }
+    else if (type == CMT_SUMMARY) {
+        metric->summary = calloc(1, sizeof(Opentelemetry__Proto__Metrics__V1__Summary));
+
+        if (metric->summary == NULL) {
+            destroy_metric(metric);
+
+            return NULL;
+        }
+
+        opentelemetry__proto__metrics__v1__summary__init(metric->summary);
+
+        metric->data_case = OPENTELEMETRY__PROTO__METRICS__V1__METRIC__DATA_SUMMARY;
+        metric->summary->data_points = initialize_summary_data_point_list(data_point_count);
+
+        if (metric->summary->data_points == NULL) {
+            destroy_metric(metric);
+
+            return NULL;
+        }
+
+        metric->summary->n_data_points = data_point_count;
+    }
+    else if (type == CMT_HISTOGRAM) {
+        metric->histogram = calloc(1, sizeof(Opentelemetry__Proto__Metrics__V1__Histogram));
+
+        if (metric->histogram == NULL) {
+            destroy_metric(metric);
+
+            return NULL;
+        }
+
+        opentelemetry__proto__metrics__v1__histogram__init(metric->histogram);
+
+        metric->data_case = OPENTELEMETRY__PROTO__METRICS__V1__METRIC__DATA_HISTOGRAM;
+        metric->histogram->data_points = initialize_histogram_data_point_list(data_point_count);
+
+        if (metric->histogram->data_points == NULL) {
+            destroy_metric(metric);
+
+            return NULL;
+        }
+
+        metric->histogram->n_data_points = data_point_count;
+        metric->histogram->aggregation_temporality = aggregation_temporality_type;
+    }
 
     return metric;
 }
 
 static int append_data_point_to_metric(
     Opentelemetry__Proto__Metrics__V1__Metric *metric,
-    Opentelemetry__Proto__Metrics__V1__NumberDataPoint *data_point,
+    void *data_point,
     size_t data_point_slot_hint)
 {
-    Opentelemetry__Proto__Metrics__V1__NumberDataPoint **data_point_list;
-    size_t                                               data_point_slot_index;
-    size_t                                               data_point_slot_count;
+    void   **data_point_list;
+    size_t   data_point_slot_index;
+    size_t   data_point_slot_count;
 
     data_point_list = NULL;
     data_point_slot_count = 0;
 
     if (metric != NULL) {
         if (metric->data_case == OPENTELEMETRY__PROTO__METRICS__V1__METRIC__DATA_SUM) {
-            data_point_list = metric->sum->data_points;
+            data_point_list = (void **) metric->sum->data_points;
             data_point_slot_count = metric->sum->n_data_points;
         }
         else if (metric->data_case == OPENTELEMETRY__PROTO__METRICS__V1__METRIC__DATA_GAUGE) {
-            data_point_list = metric->gauge->data_points;
+            data_point_list = (void **) metric->gauge->data_points;
             data_point_slot_count = metric->gauge->n_data_points;
+        }
+        else if (metric->data_case == OPENTELEMETRY__PROTO__METRICS__V1__METRIC__DATA_SUMMARY) {
+            data_point_list = (void **) metric->summary->data_points;
+            data_point_slot_count = metric->summary->n_data_points;
+        }
+        else if (metric->data_case == OPENTELEMETRY__PROTO__METRICS__V1__METRIC__DATA_HISTOGRAM) {
+            data_point_list = (void **) metric->histogram->data_points;
+            data_point_slot_count = metric->histogram->n_data_points;
         }
     }
 
@@ -1107,14 +1673,17 @@ int append_sample_to_metric(struct cmt_opentelemetry_context *context,
                             struct cmt_metric *sample,
                             size_t sample_index)
 {
+    double                                              dummy_sum_quantile_list[5];
     size_t                                              attribute_index;
     size_t                                              attribute_count;
     Opentelemetry__Proto__Common__V1__KeyValue        **attribute_list;
     struct cmt_label                                   *static_label;
     struct cmt_map_label                               *label_value;
     struct cmt_map_label                               *label_name;
-    Opentelemetry__Proto__Metrics__V1__NumberDataPoint *data_point;
+    void                                               *data_point;
     Opentelemetry__Proto__Common__V1__KeyValue         *attribute;
+    struct cmt_histogram                               *histogram;
+    struct cmt_summary                                 *summary;
     int                                                 result;
     struct mk_list                                     *head;
 
@@ -1127,11 +1696,49 @@ int append_sample_to_metric(struct cmt_opentelemetry_context *context,
         return -1;
     }
 
-    data_point = initialize_double_data_point(0,
-                                              cmt_metric_get_timestamp(sample),
-                                              cmt_metric_get_value(sample),
-                                              attribute_list,
-                                              attribute_count);
+    if (map->type == CMT_COUNTER   ||
+        map->type == CMT_GAUGE     ||
+        map->type == CMT_UNTYPED   ) {
+        data_point = initialize_numerical_data_point(0,
+                                                     cmt_metric_get_timestamp(sample),
+                                                     cmt_metric_get_value(sample),
+                                                     attribute_list,
+                                                     attribute_count);
+    }
+    else if (map->type == CMT_SUMMARY) {
+        summary = (struct cmt_summary *) map->parent;
+
+        dummy_sum_quantile_list[0] = 0.1;
+        dummy_sum_quantile_list[1] = 0.2;
+        dummy_sum_quantile_list[2] = 0.3;
+        dummy_sum_quantile_list[3] = 0.4;
+        dummy_sum_quantile_list[4] = 0.5;
+
+        data_point = initialize_summary_data_point(0,
+                                                   cmt_metric_get_timestamp(sample),
+                                                   cmt_summary_get_count_value(sample),
+                                                   cmt_summary_get_sum_value(sample),
+                                                   5,
+                                                   dummy_sum_quantile_list,
+                                                   5,
+                                                   sample->sum_quantiles,
+                                                   attribute_list,
+                                                   attribute_count);
+    }
+    else if (map->type == CMT_HISTOGRAM) {
+        histogram = (struct cmt_histogram *) map->parent;
+
+        data_point = initialize_histogram_data_point(0,
+                                                     cmt_metric_get_timestamp(sample),
+                                                     cmt_metric_hist_get_count_value(sample),
+                                                     cmt_metric_hist_get_sum_value(sample),
+                                                     histogram->buckets->count,
+                                                     sample->hist_buckets,
+                                                     histogram->buckets->count,
+                                                     histogram->buckets->upper_bounds,
+                                                     attribute_list,
+                                                     attribute_count);
+    }
 
     if (data_point == NULL) {
         destroy_attribute_list(attribute_list);
@@ -1148,18 +1755,19 @@ int append_sample_to_metric(struct cmt_opentelemetry_context *context,
                                                 static_label->val);
 
         if (attribute == NULL) {
-            destroy_data_point(data_point);
+            destroy_data_point(data_point, map->type);
 
             return -3;
         }
 
         result = append_attribute_to_data_point(data_point,
+                                                map->type,
                                                 attribute,
                                                 attribute_index++);
 
         if (result != 0)
         {
-            destroy_data_point(data_point);
+            destroy_data_point(data_point, map->type);
 
             return -4;
         }
@@ -1174,18 +1782,19 @@ int append_sample_to_metric(struct cmt_opentelemetry_context *context,
                                                 label_value->name);
 
         if (attribute == NULL) {
-            destroy_data_point(data_point);
+            destroy_data_point(data_point, map->type);
 
             return -5;
         }
 
         result = append_attribute_to_data_point(data_point,
+                                                map->type,
                                                 attribute,
                                                 attribute_index++);
 
         if (result != 0)
         {
-            destroy_data_point(data_point);
+            destroy_data_point(data_point, map->type);
 
             return -6;
         }
@@ -1194,10 +1803,10 @@ int append_sample_to_metric(struct cmt_opentelemetry_context *context,
                                         _head, &map->label_keys);
     }
 
-    result = append_data_point_to_metric(metric, data_point, sample_index);
+    result = append_data_point_to_metric(metric, (void *) data_point, sample_index);
 
     if (result != 0) {
-        destroy_data_point(data_point);
+        destroy_data_point(data_point, map->type);
 
         return -7;
     }
@@ -1337,6 +1946,8 @@ cmt_sds_t cmt_encode_opentelemetry_create(struct cmt *cmt)
     size_t                            metric_count;
     size_t                            metric_index;
     struct cmt_opentelemetry_context *context;
+    struct cmt_histogram             *histogram;
+    struct cmt_summary               *summary;
     struct cmt_untyped               *untyped;
     struct cmt_counter               *counter;
     int                               result;
@@ -1385,6 +1996,28 @@ cmt_sds_t cmt_encode_opentelemetry_create(struct cmt *cmt)
         mk_list_foreach(head, &cmt->untypeds) {
             untyped = mk_list_entry(head, struct cmt_untyped, _head);
             result = pack_basic_type(context, untyped->map, &metric_index);
+
+            if (result != CMT_ENCODE_OPENTELEMETRY_SUCCESS) {
+                break;
+            }
+        }
+    }
+
+    if (result == CMT_ENCODE_OPENTELEMETRY_SUCCESS) {
+        mk_list_foreach(head, &cmt->summaries) {
+            summary = mk_list_entry(head, struct cmt_summary, _head);
+            result = pack_basic_type(context, summary->map, &metric_index);
+
+            if (result != CMT_ENCODE_OPENTELEMETRY_SUCCESS) {
+                break;
+            }
+        }
+    }
+
+    if (result == CMT_ENCODE_OPENTELEMETRY_SUCCESS) {
+        mk_list_foreach(head, &cmt->histograms) {
+            histogram = mk_list_entry(head, struct cmt_histogram, _head);
+            result = pack_basic_type(context, histogram->map, &metric_index);
 
             if (result != CMT_ENCODE_OPENTELEMETRY_SUCCESS) {
                 break;

--- a/tests/encoding.c
+++ b/tests/encoding.c
@@ -575,29 +575,7 @@ void test_opentelemetry()
 
     cmt_initialize();
 
-    cmt = cmt_create();
-    TEST_CHECK(cmt != NULL);
-
-    c = cmt_counter_create(cmt, "cmt", "labels", "test", "Static labels test",
-                           2, (char *[]) {"host", "app"});
-
-    ts = 0;
-    cmt_counter_inc(c, ts, 0, NULL);
-    cmt_counter_inc(c, ts, 2, (char *[]) {"calyptia.com", "cmetrics"});
-    cmt_counter_inc(c, ts, 2, (char *[]) {"calyptia.com", "cmetrics2"});
-
-    g = cmt_gauge_create(cmt, "cmt", "labels", "test 2", "Static labels test",
-                           2, (char *[]) {"host", "app2"});
-
-    ts = 0;
-    cmt_gauge_set(g, ts, 11.0f, 0, NULL);
-    cmt_gauge_inc(g, ts, 0, NULL);
-    cmt_gauge_inc(g, ts, 2, (char *[]) {"calyptia.com.ar", "cmetrics"});
-    cmt_gauge_inc(g, ts, 2, (char *[]) {"calyptia.com.ar", "cmetrics2"});
-
-    /* append static labels */
-    cmt_label_add(cmt, "dev", "Calyptia");
-    cmt_label_add(cmt, "lang", "C");
+    cmt = generate_encoder_test_data();
 
     payload = cmt_encode_opentelemetry_create(cmt);
     TEST_CHECK(NULL != payload);
@@ -608,15 +586,13 @@ void test_opentelemetry()
         return;
     }
 
-    printf("\n\nDumping remote write payload to payload.bin, in order to test it \
-we need to compress it using snappys scmd :\n\
-scmd -c payload.bin payload.snp\n\n\
-and then send it using curl :\n\
-curl -v 'http://localhost:9090/receive' -H 'Content-Type: application/x-protobuf' \
--H 'X-Prometheus-Remote-Write-Version: 0.1.0' -H 'User-Agent: metrics-worker' \
---data-binary '@payload.snp'\n\n");
+    printf("\n\nDumping remote write payload to opentelemetry_payload.bin, in order to test it \
+we need to send it to our opentelemetry http endpoint using curl :\n\
+curl -v 'http://localhost:9090/v1/metrics' -H 'Content-Type: application/x-protobuf' \
+-H 'User-Agent: metrics-worker' \
+--data-binary '@opentelemetry_payload.bin'\n\n");
 
-    sample_file = fopen("payload.bin", "wb+");
+    sample_file = fopen("opentelemetry_payload.bin", "wb+");
 
     fwrite(payload, 1, cmt_sds_len(payload), sample_file);
 


### PR DESCRIPTION
There is still one issue, because `cmt_summary` does not have a list of quantile boundaries I had to put dummy values at the moment  in [cmt_encode_opentelemetry.c#L1711](https://github.com/calyptia/cmetrics/blob/e97973dc05b2843cb956efadc15c26cb4b575a94/src/cmt_encode_opentelemetry.c#L1711).

Signed-off-by: Leonardo Alminana <leonardo@calyptia.com>