### PR TITLE
Prometheus decoder support null labels

### DIFF
--- a/include/cmetrics/cmt_decode_prometheus.h
+++ b/include/cmetrics/cmt_decode_prometheus.h
@@ -47,7 +47,6 @@ enum cmt_decode_prometheus_context_sample_type {
 struct cmt_decode_prometheus_context_sample {
     char value1[64];
     char value2[64];
-    size_t label_count;
     int type;
     cmt_sds_t label_values[CMT_DECODE_PROMETHEUS_MAX_LABEL_COUNT];
 

--- a/src/cmt_encode_prometheus.c
+++ b/src/cmt_encode_prometheus.c
@@ -247,7 +247,12 @@ static void format_metric(struct cmt *cmt,
 
     /* Static labels */
     static_labels = cmt_labels_count(cmt->static_labels);
-    defined_labels = mk_list_size(&metric->labels);
+    mk_list_foreach(head, &metric->labels) {
+        label_v = mk_list_entry(head, struct cmt_map_label, _head);
+        if (strlen(label_v->name)) {
+            defined_labels++;
+        }
+    }
 
     if (!fmt->brace_open && (static_labels + defined_labels > 0)) {
         cmt_sds_cat_safe(buf, "{", 1);
@@ -272,12 +277,15 @@ static void format_metric(struct cmt *cmt,
         mk_list_foreach(head, &metric->labels) {
             label_v = mk_list_entry(head, struct cmt_map_label, _head);
 
-            fmt->labels_count += add_label(buf, label_k->name, label_v->name);
+            if (strlen(label_v->name)) {
+                fmt->labels_count += add_label(buf, label_k->name, label_v->name);
+                if (i < defined_labels) {
+                    cmt_sds_cat_safe(buf, ",", 1);
+                }
 
-            if (i < defined_labels) {
-                cmt_sds_cat_safe(buf, ",", 1);
+                i++;
             }
-            i++;
+
             label_k = mk_list_entry_next(&label_k->_head, struct cmt_map_label,
                                          _head, &map->label_keys);
         }


### PR DESCRIPTION
This PR fixes a problem with prometheus encoding when labels are NULL. Also enables support on decoder.