### PR TITLE
summary: fix quantiles api

### DIFF
--- a/include/cmetrics/cmt_metric.h
+++ b/include/cmetrics/cmt_metric.h
@@ -33,7 +33,7 @@ struct cmt_metric {
 
     /* summary */
     int sum_quantiles_set;     /* specify if quantive values has been set */
-    uint64_t sum_quantiles[5]; /* 0, 0.25, 0.5, 0.75 and 1 */
+    uint64_t *sum_quantiles;   /* 0, 0.25, 0.5, 0.75 and 1 */
     uint64_t sum_count;
     uint64_t sum_sum;
 

--- a/include/cmetrics/cmt_summary.h
+++ b/include/cmetrics/cmt_summary.h
@@ -29,15 +29,23 @@
  * any other involved variable. We won't do calculations.
  */
 struct cmt_summary {
+    /* summary specific */
+    double *quantiles;
+    size_t quantiles_count;
+
+    /* metrics common */
     struct cmt_opts opts;
     struct cmt_map *map;
     struct mk_list _head;
     struct cmt *cmt;
+
 };
 
 struct cmt_summary *cmt_summary_create(struct cmt *cmt,
                                        char *ns, char *subsystem,
                                        char *name, char *help,
+                                       size_t quantiles_count,
+                                       double *quantiles,
                                        int label_count, char **label_keys);
 
 int cmt_summary_destroy(struct cmt_summary *summary);

--- a/src/cmt_decode_prometheus.c
+++ b/src/cmt_decode_prometheus.c
@@ -187,7 +187,7 @@ static int split_metric_name(struct cmt_decode_prometheus_context *context,
 // Use this helper function to return a stub value for docstring when it is not
 // available. This is necessary for now because the metric constructors require
 // a docstring, even though it is not required by prometheus spec.
-static const char *get_docstring(struct cmt_decode_prometheus_context *context)
+static char *get_docstring(struct cmt_decode_prometheus_context *context)
 {
     return context->metric.docstring ? context->metric.docstring : "(no information)";
 }
@@ -636,6 +636,8 @@ static int add_metric_summary(struct cmt_decode_prometheus_context *context)
             context->metric.subsystem,
             context->metric.name,
             get_docstring(context),
+            quantile_count,
+            /* FIXME */ (double *) NULL,
             0, NULL);
 
     if (!s) {

--- a/src/cmt_map.c
+++ b/src/cmt_map.c
@@ -154,6 +154,10 @@ static void map_metric_destroy(struct cmt_metric *metric)
     if (metric->hist_buckets) {
         free(metric->hist_buckets);
     }
+    if (metric->sum_quantiles) {
+        free(metric->sum_quantiles);
+    }
+
     mk_list_del(&metric->_head);
     free(metric);
 }

--- a/tests/encoding.c
+++ b/tests/encoding.c
@@ -149,6 +149,7 @@ static struct cmt *generate_encoder_test_data()
 
     s1 = cmt_summary_create(cmt,
                             "k8s", "disk", "load", "Disk load",
+                            /* FIXME */ 0, 0,
                             1, (char *[]) {"my_label"});
 
     ts = 0;

--- a/tests/summary.c
+++ b/tests/summary.c
@@ -52,9 +52,17 @@ void test_set_defaults()
     cmt = cmt_create();
     TEST_CHECK(cmt != NULL);
 
+    /* set quantiles, no labels */
+    q[0] = 0.1;
+    q[1] = 0.2;
+    q[2] = 0.3;
+    q[3] = 0.4;
+    q[4] = 0.5;
+
     /* Create a gauge metric type */
     s = cmt_summary_create(cmt,
                            "k8s", "network", "load", "Network load",
+                           5, q,
                            1, (char *[]) {"my_label"});
     TEST_CHECK(s != NULL);
 
@@ -64,13 +72,6 @@ void test_set_defaults()
     /* no quantiles, no labels */
     cmt_summary_set_default(s, ts, NULL, sum, count, 0, NULL);
     prometheus_encode_test(cmt);
-
-    /* set quantiles, no labels */
-    q[0] = 0.1;
-    q[1] = 0.2;
-    q[2] = 0.3;
-    q[3] = 0.4;
-    q[4] = 0.5;
 
     cmt_summary_set_default(s, ts, q, sum, count, 0, NULL);
     prometheus_encode_test(cmt);


### PR DESCRIPTION
the following PR changes the summary creation prototype, not it accepts a number of expected quantiles and it quantile value.

in the _set_default api allows to specify the final value for each quantile