### PR TITLE
map: free static metric sum_quantiles on destroy

### DIFF
--- a/src/cmt_map.c
+++ b/src/cmt_map.c
@@ -275,14 +275,22 @@ void cmt_map_destroy(struct cmt_map *map)
         map_metric_destroy(metric);
     }
 
-    /* histogram allocation for static metric */
-    if (map->metric_static_set && map->type == CMT_HISTOGRAM) {
+    /* histogram and quantile allocation for static metric */
+    if (map->metric_static_set) {
         metric = &map->metric;
-        if (metric->hist_buckets) {
-            free(metric->hist_buckets);
-        }
 
+        if (map->type == CMT_HISTOGRAM) {
+            if (metric->hist_buckets) {
+                free(metric->hist_buckets);
+            }
+        }
+        else if (map->type == CMT_SUMMARY) {
+            if (metric->sum_quantiles) {
+                free(metric->sum_quantiles);
+            }
+        }
     }
+
     free(map);
 }
 


### PR DESCRIPTION
Summary quantiles were being properly released for dynamic metrics (samples with labels) but not for static metrics, this fixes PR that.

Signed-off-by: Leonardo Alminana <leonardo@calyptia.com>