### PR TITLE
encoding: influx & text: added histogram and summary support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,7 +26,7 @@ endif()
 # CMetrics Version
 set(CMT_VERSION_MAJOR  0)
 set(CMT_VERSION_MINOR  3)
-set(CMT_VERSION_PATCH  0)
+set(CMT_VERSION_PATCH  3)
 set(CMT_VERSION_STR "${CMT_VERSION_MAJOR}.${CMT_VERSION_MINOR}.${CMT_VERSION_PATCH}")
 
 # Define __FILENAME__ consistently across Operating Systems

--- a/src/cmt_decode_msgpack.c
+++ b/src/cmt_decode_msgpack.c
@@ -737,7 +737,7 @@ static int unpack_metric(mpack_reader_t *reader,
     if (decode_context->map->type == CMT_HISTOGRAM) {
         histogram = decode_context->map->parent;
 
-        metric->hist_buckets = calloc(histogram->buckets->count, sizeof(uint64_t));
+        metric->hist_buckets = calloc(histogram->buckets->count + 1, sizeof(uint64_t));
 
         if (metric->hist_buckets == NULL) {
             cmt_errno();

--- a/src/cmt_encode_msgpack.c
+++ b/src/cmt_encode_msgpack.c
@@ -328,10 +328,9 @@ static int pack_metric(mpack_writer_t *writer, struct cmt_map *map, struct cmt_m
         mpack_start_map(writer, 3);
 
         mpack_write_cstr(writer, "buckets");
-        mpack_start_array(writer, histogram->buckets->count);
-
+        mpack_start_array(writer, histogram->buckets->count + 1);
         for (index = 0 ;
-             index < histogram->buckets->count ;
+             index <= histogram->buckets->count ;
              index++) {
             mpack_write_uint(writer, cmt_metric_hist_get_value(metric, index));
         }


### PR DESCRIPTION
The text representation for histograms and summaries replaces the value with something like this : 

`{ quantiles = { N=N, N=N, N=N }, count=N, sum=N }`  and `{ buckets = { N=N, N=N, N=N }, count=N, sum=N }` 

As for influxdb, I followed version 1 of the format used to store prometheus metrics because that seemed to be the format we had been using : https://docs.influxdata.com/influxdb/v2.1/reference/prometheus-metrics/

This PR does not include any unit test changes but I was thinking about enhancing the context generated by `generate_encoder_test_data` and using that in all the tests to simplify things. That is what I did to test it while developing but opted not to make the change in the same PR to keep things clean.