### PR TITLE
macos: cpack: Support productbuild package creation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,6 +18,11 @@ if(CMAKE_SYSTEM_NAME MATCHES "Windows")
   message(STATUS "Specifying YY_NO_UNISTD_H")
 endif()
 
+# Define macro to identify macOS system
+if(CMAKE_SYSTEM_NAME MATCHES "Darwin")
+  set(CMT_SYSTEM_MACOS On)
+  add_definitions(-DCMT_SYSTEM_MACOS)
+endif()
 
 if(NOT MSVC)
   set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall")
@@ -222,6 +227,7 @@ endif()
 # Enable components
 set(CPACK_DEB_COMPONENT_INSTALL ON)
 set(CPACK_RPM_COMPONENT_INSTALL ON)
+set(CPACK_productbuild_COMPONENT_INSTALL ON)
 set(CPACK_COMPONENTS_ALL ${CPACK_COMPONENTS_ALL} binary library headers)
 set(CPACK_COMPONENTS_GROUPING "ONE_PER_GROUP")
 
@@ -273,6 +279,42 @@ set(CPACK_DEBIAN_PACKAGE_SHLIBDEPS ON)
 if(CPACK_GENERATOR MATCHES "ZIP")
   set(CPACK_MONOLITHIC_INSTALL 1)
   set(CPACK_PACKAGE_INSTALL_DIRECTORY "cmetrics")
+endif()
+
+# CPack: macOS w/ productbuild
+if(CMT_SYSTEM_MACOS)
+  # Determine the platform suffix
+  execute_process(
+    COMMAND uname -m
+    RESULT_VARIABLE UNAME_M_RESULT
+    OUTPUT_VARIABLE UNAME_ARCH
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+    )
+  if (UNAME_M_RESULT EQUAL 0 AND UNAME_ARCH STREQUAL "arm64")
+    set(CMETRICS_PKG ${CMAKE_CURRENT_BINARY_DIR}/${CPACK_PACKAGE_NAME}-${CMT_VERSION_STR}-apple)
+  elseif(UNAME_M_RESULT EQUAL 0 AND UNAME_ARCH STREQUAL "x86_64")
+    set(CMETRICS_PKG ${CMAKE_CURRENT_BINARY_DIR}/${CPACK_PACKAGE_NAME}-${CMT_VERSION_STR}-intel)
+  else()
+    set(CMETRICS_PKG ${CMAKE_CURRENT_BINARY_DIR}/${CPACK_PACKAGE_NAME}-${CMT_VERSION_STR}-${UNAME_ARCH})
+  endif()
+
+  if (CPACK_GENERATOR MATCHES "productbuild")
+    set(CPACK_SET_DESTDIR "ON")
+    configure_file(cpack/macos/welcome.txt.cmakein ${CMAKE_CURRENT_BINARY_DIR}/welcome.txt)
+    configure_file(LICENSE ${CMAKE_CURRENT_BINARY_DIR}/LICENSE.txt)
+    find_program(CONVERTER textutil)
+    if (NOT CONVERTER)
+      message(FATAL_ERROR "textutil not found.")
+    endif()
+    if (CONVERTER)
+      execute_process(COMMAND ${CONVERTER} -convert html "${CMAKE_SOURCE_DIR}/README.md" -output "${CMAKE_BINARY_DIR}/README.html")
+    endif()
+    set(CPACK_PACKAGE_FILE_NAME "${CMETRICS_PKG}")
+    set(CPACK_RESOURCE_FILE_WELCOME ${CMAKE_CURRENT_BINARY_DIR}/welcome.txt)
+    set(CPACK_RESOURCE_FILE_LICENSE ${CMAKE_CURRENT_BINARY_DIR}/LICENSE.txt)
+    set(CPACK_RESOURCE_FILE_README ${CMAKE_CURRENT_BINARY_DIR}/README.html)
+    set(CPACK_PRODUCTBUILD_IDENTIFIER "com.calyptia.${CPACK_PACKAGE_NAME}")
+  endif()
 endif()
 
 include(CPack)

--- a/cpack/macos/welcome.txt.cmakein
+++ b/cpack/macos/welcome.txt.cmakein
@@ -1,0 +1,7 @@
+This will install @CPACK_PACKAGE_NAME@ on your Mac.
+
+--------------------------------------------------
+
+Thank you for trying @CPACK_PACKAGE_NAME@! Have a fantastic day!
+
+You can use @CPACK_PACKAGE_NAME@ as metrics library on your system.


### PR DESCRIPTION
I got succeeded to build macOS installer package w/ cpack's productbuild generator.

This package can be built with:

```console
$ cd /path/to/cmetrics-workdir/build
$ cmake -DCPACK_GENERATOR=productbuild ..
$ cpack -G productbuild 
```

Then, `cmetrics-<cmetrics version>-(apple|intel).pkg` installer will be generated.

Signed-off-by: Hiroshi Hatake <hatake@calyptia.com>