### PR TITLE
decoding: opentelemetry decoder fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,7 +31,7 @@ endif()
 # CMetrics Version
 set(CMT_VERSION_MAJOR  0)
 set(CMT_VERSION_MINOR  3)
-set(CMT_VERSION_PATCH  1)
+set(CMT_VERSION_PATCH  2)
 set(CMT_VERSION_STR "${CMT_VERSION_MAJOR}.${CMT_VERSION_MINOR}.${CMT_VERSION_PATCH}")
 
 # Define __FILENAME__ consistently across Operating Systems

--- a/src/cmt_decode_opentelemetry.c
+++ b/src/cmt_decode_opentelemetry.c
@@ -237,6 +237,7 @@ static int append_new_map_label_key(struct cmt_map *map, char *name)
     }
 
     mk_list_add(&label->_head, &map->label_keys);
+    map->label_count++;
 
     return CMT_DECODE_OPENTELEMETRY_SUCCESS;
 }
@@ -920,6 +921,13 @@ static int decode_metrics_entry(struct cmt *cmt,
     metric_namespace = "";
     metric_subsystem = "";
     metric_description = metric->description;
+
+    if (metric_description == NULL) {
+        metric_description = "-";
+    }
+    else if (strlen(metric_description) == 0) {
+        metric_description = "-";
+    }
 
     if (metric->data_case == OPENTELEMETRY__PROTO__METRICS__V1__METRIC__DATA_SUM) {
         instance = cmt_counter_create(cmt,


### PR DESCRIPTION
This PR fixes a bug in the opentelemetry decoder where metric label counts were not incremented causing the msgpack encoder
to generate incorrect data.

Additionally a dummy help string is used when none is received due to a limitation in cmetrics where metric constructors do not allow empty help strings.