### PR TITLE
encoding: opentelemetry: issue 131 fix

### DIFF
--- a/src/cmt_encode_opentelemetry.c
+++ b/src/cmt_encode_opentelemetry.c
@@ -1577,10 +1577,6 @@ int append_sample_to_metric(struct cmt_opentelemetry_context *context,
     else if (map->type == CMT_SUMMARY) {
         summary = (struct cmt_summary *) map->parent;
 
-        if (sample->sum_quantiles_set == CMT_FALSE) {
-            return CMT_ENCODE_OPENTELEMETRY_SUCCESS;
-        }
-
         data_point = initialize_summary_data_point(0,
                                                    cmt_metric_get_timestamp(sample),
                                                    cmt_summary_get_count_value(sample),

--- a/tests/encode_output.c
+++ b/tests/encode_output.c
@@ -59,9 +59,9 @@ int cmt_test_encode_all(struct cmt *cmt)
     sds_buf = cmt_encode_influx_create(cmt);
     cmt_encode_influx_destroy(sds_buf);
 
-    /* opentelemetry FIXME: the encoding is crashing */
-    //sds_buf = cmt_encode_opentelemetry_create(cmt);
-    //cmt_encode_opentelemetry_destroy(sds_buf);
+    /* opentelemetry */
+    sds_buf = cmt_encode_opentelemetry_create(cmt);
+    cmt_encode_opentelemetry_destroy(sds_buf);
 
     return 0;
 }


### PR DESCRIPTION
This PR makes removes a previous behavior in the OTLP encoder where it skipped part of the summary encoding process if `quantiles_set` was set to `CMT_FALSE`.