### PR TITLE
build: Add option to disable prometheus decoder

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,9 +42,10 @@ else()
 endif()
 
 # Configuration options
-option(CMT_DEV             "Enable development mode"                   No)
-option(CMT_TESTS           "Enable unit testing"                       No)
-option(CMT_INSTALL_TARGETS "Enable subdirectory library installations" Yes)
+option(CMT_DEV                       "Enable development mode"                   No)
+option(CMT_TESTS                     "Enable unit testing"                       No)
+option(CMT_INSTALL_TARGETS           "Enable subdirectory library installations" Yes)
+option(CMT_ENABLE_PROMETHEUS_DECODER "Enable prometheus decoder"                 Yes)
 
 if(CMT_DEV)
   set(CMT_TESTS   Yes)
@@ -119,18 +120,20 @@ check_c_source_compiles("
      return 0;
   }" CMT_HAVE_MSGPACK)
 
-# Flex and Bison: check if the variables has not been defined before by
-# a parent project to avoid conflicts.
-if(NOT FLEX_FOUND)
-  find_package(FLEX 2)
-endif()
+if(CMT_ENABLE_PROMETHEUS_DECODER)
+    # Flex and Bison: check if the variables has not been defined before by
+    # a parent project to avoid conflicts.
+    if(NOT FLEX_FOUND)
+      find_package(FLEX 2)
+    endif()
 
-if(NOT BISON_FOUND)
-  find_package(BISON 3)
-endif()
+    if(NOT BISON_FOUND)
+      find_package(BISON 3)
+    endif()
 
-if(FLEX_FOUND AND BISON_FOUND)
-    set(CMT_BUILD_PROMETHEUS_DECODER 1)
+    if(FLEX_FOUND AND BISON_FOUND)
+        set(CMT_BUILD_PROMETHEUS_DECODER 1)
+    endif()
 endif()
 
 configure_file(


### PR DESCRIPTION
This option can be useful when building on systems that have broken versions of bison/flex.

Signed-off-by: Thiago Padilha <thiago@calyptia.com>