### PR TITLE
ci: appveyor: Explicitly invoke `git submodule` from build script

### DIFF
--- a/scripts/win_build.bat
+++ b/scripts/win_build.bat
@@ -1,6 +1,7 @@
 setlocal
 call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\Common7\Tools\VsDevCmd.bat"
 path "C:\Program Files (x86)\MSBuild\16.0\Bin;C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\MSBuild\Current\Bin";%path%
+git submodule update --init --recursive
 cd build
 cmake -G "NMake Makefiles"  -DCMT_TESTS=On ..\
 cmake --build .


### PR DESCRIPTION
Note that CFL build still fails due to some missing definitions

Signed-off-by: Thiago Padilha <thiago@calyptia.com>