### PR TITLE
encoding: msgpack: fixed missing static labels bug

### DIFF
--- a/src/cmt_encode_opentelemetry.c
+++ b/src/cmt_encode_opentelemetry.c
@@ -961,6 +961,9 @@ static Opentelemetry__Proto__Metrics__V1__ResourceMetrics *
     if (metadata != NULL) {
         resource_metrics->schema_url = fetch_metadata_string_key(metadata, "schema_url", &error_detection_flag);
     }
+    else {
+        error_detection_flag = CMT_FALSE;
+    }
 
     if (error_detection_flag) {
         destroy_resource_metrics(resource_metrics);


### PR DESCRIPTION
This PR fixes a bug that caused static labels to be lost when decoding a msgpack encoded context, additionally, static labels were moved to the global meta->processing section.

There is also a minor fix in the otlp encoder for an uninitialized variable access.